### PR TITLE
chore: Configure semantic-release npm to publish the correct directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,21 @@
     "branches": [
       "master"
     ],
-    "dryRun": true
+    "dryRun": true,
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/npm",
+        {
+          "pkgRoot": "./dist/stream-chat-angular",
+          "npmPublish": false
+        }
+      ],
+      [
+        "@semantic-release/github"
+      ]
+    ]
   },
   "dependencies": {
     "@angular/animations": "~12.2.0",


### PR DESCRIPTION
closes #13 