### PR TITLE
docs: Fix broken markdown links

### DIFF
--- a/docusaurus/docs/Angular/components/message-reactions.mdx
+++ b/docusaurus/docs/Angular/components/message-reactions.mdx
@@ -51,11 +51,11 @@ export class CustomMessageComponent {
 
 ### <div class="label required basic">Required</div> messageReactionCounts
 
-The number of reactions grouped by [reaction types](<(https://github.com/GetStream/stream-chat-angular/tree/master/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts)>)
+The number of reactions grouped by [reaction types](https://github.com/GetStream/stream-chat-angular/tree/master/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts)
 
-| Type                                                                                                                                                                                                  | Default |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| { [key in [`MessageReactionType`](<(https://github.com/GetStream/stream-chat-angular/tree/master/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts)>)]?: number } | {}      |
+| Type                                                                                                                                                                                              | Default |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| { [key in [`MessageReactionType`](https://github.com/GetStream/stream-chat-angular/tree/master/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts)]?: number } | {}      |
 
 ### latestReactions
 


### PR DESCRIPTION
The links changed currently point to `https://getstream.io/chat/docs/sdk/angular/components/message-reactions/(https://github.com/GetStream/stream-chat-angular/tree/master/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts)/`.

These were reported as broken by the docusaurus validator. 