### PR TITLE
refactor: Message action inputs and capability checks

### DIFF
--- a/docusaurus/docs/Angular/components/message-actions.mdx
+++ b/docusaurus/docs/Angular/components/message-actions.mdx
@@ -6,18 +6,7 @@ title: Message actions
 
 import MessageActionsScreenshot from "../assets/message-actions-screenshot.png";
 
-The `MessageActionsBox` component displays a list of message actions (i.e edit), that can be opened or closed. The following actions are supported:
-
-| Name         | Description                                                                                          | Necessary channel capability             |
-| ------------ | ---------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| `flag`       | [Flags](https://getstream.io/chat/docs/javascript/moderation/?language=javascript) the given message | flag-message                             |
-| `edit`       | Edits a message that belongs to the user                                                             | update-own-message or update-any-message |
-| `edit-any`   | Edits any message                                                                                    | update-any-message                       |
-| `delete`     | Deletes a message that belongs to the user                                                           | delete-own-message or delete-any-message |
-| `delete-any` | Deletes any message                                                                                  | delete-any-message                       |
-| `pin`        | Not yet impelemented                                                                                 | -                                        |
-| `quoute`     | Not yet impelemented                                                                                 | -                                        |
-| `mute`       | Not yet impelemented                                                                                 | -                                        |
+The `MessageActionsBox` component displays a list of message actions (i.e edit), that can be opened or closed. You can find the [list of the supported actions](../concepts/message-interactions.mdx) in the message interaction guide.
 
 **Example 1** - example message actions with the message component:
 
@@ -34,7 +23,6 @@ A typical use case for the `MessageActionsBox` component would be to use in your
     <stream-message-actions-box
       [isOpen]="isActionBoxOpen"
       [isMine]="isMessageSentByCurrentUser"
-      [enabledActions]="actions"
     ></stream-message-actions-box>
     <!-- Other parts of the custom message component -->
   `,
@@ -43,7 +31,6 @@ export class CustomMessageComponent {
   @Input() message: StreamMessage;
   isActionBoxOpen: boolean;
   isMessageSentByCurrentUser: boolean;
-  actions = ["flag", "edit", "edit-any", "delete", "delete-any"];
 }
 ```
 
@@ -77,7 +64,7 @@ Indicates if the message actions are belonging to a message that was sent by the
 
 ### <div class="label required basic">Required</div> enabledActions
 
-The list of actions that are enabled. To disable all actions, provide an empty array. Currently only message [flags](https://getstream.io/chat/docs/javascript/moderation/?language=javascript) are implemented.
+The list of [channel capabilities](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript) that are enabled for the current user, the list of [supported interactions](../concepts/message-interactions.mdx) can be found in our message interaction guide. Unathorized actions won't be displayed on the UI.
 
 | Type                                                                                                                                                                        | Default |
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |

--- a/docusaurus/docs/Angular/components/message-input.mdx
+++ b/docusaurus/docs/Angular/components/message-input.mdx
@@ -80,7 +80,7 @@ If no value is provided, it is set from the [`MessageInputConfigService`](../ser
 | ------- |
 | boolean |
 
-### <div class="label caution basic">Caution</div> acceptedFileTypes
+### <div class="label caution basic">Caution</div> acceptedFileTypes **DEPRECATED**
 
 **DEPRECATED** use [application settings](https://getstream.io/chat/docs/javascript/app_setting_overview/?language=javascript#file-uploads) instead
 

--- a/docusaurus/docs/Angular/components/message-list.mdx
+++ b/docusaurus/docs/Angular/components/message-list.mdx
@@ -7,7 +7,7 @@ title: Message list
 import MessagesWithGroupingsScreenhot from "../assets/messages-with-grouping-screenshot.png";
 import MessagesWithoutGroupingsScreenhot from "../assets/messages-without-groups-screenshot.png";
 
-The `MessageList` component renders a scrollable list of messages. The list renders new message notifications, and standard messages containing text and/or attachments.
+The `MessageList` component renders a scrollable list of messages.
 
 The `MessageList` displays messages using pagination, new messages are loaded when the user scrolls to the top of the list.
 
@@ -75,7 +75,9 @@ The template used to display a mention in a message. It receives the mentioned u
 | ----------- |
 | TemplateRef |
 
-### areReactionsEnabled
+### <div class="label caution basic">Caution</div> areReactionsEnabled **DEPRECATED**
+
+**DEPRECATED** use [channel capabilities](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript) instead
 
 If true, the message reactions are displayed. Users can also react to messages if they have the necessary [channel capability](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript).
 
@@ -83,10 +85,12 @@ If true, the message reactions are displayed. Users can also react to messages i
 | ------- | ------- |
 | boolean | true    |
 
-### enabledMessageActions
+### <div class="label caution basic">Caution</div> enabledMessageActions **DEPRECATED**
+
+**DEPRECATED** use [channel capabilities](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript) instead
 
 The list of [actions that are enabled](./message-actions.mdx), please note that the user also has to have the necessary [channel capabilities](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript) for actions to work. Unathorized actions won't be displayed on the UI. The `MessgaeList` component makes the necessary checks before passing the actions to the `Message` component.
 
-| Type            | Default                                              |
-| --------------- | ---------------------------------------------------- |
-| MessageAction[] | ['flag', 'edit', 'edit-any', 'delete', 'delete-any'] |
+| Type            | Default                                                  |
+| --------------- | -------------------------------------------------------- |
+| MessageAction[] | undefined (enable actions based on channel capabilities) |

--- a/docusaurus/docs/Angular/components/message.mdx
+++ b/docusaurus/docs/Angular/components/message.mdx
@@ -8,7 +8,7 @@ import MessageScreenshot from "../assets/message-screenshot.png";
 import MessageActionsScreenshot from "../assets/message-actions-screenshot.png";
 import MessageReactionsScreenshot from "../assets/message-reactions-screenshot.png";
 
-The `Message` component displays a message with additional information such as sender and date, and enables interaction with the message (i.e. edit or react).
+The `Message` component displays a message with additional information such as sender and date, and enables [interaction with the message (i.e. edit or react)](../concepts/message-interactions.mdx).
 
 **Example 1** - example message:
 
@@ -41,13 +41,11 @@ The message list uses the `Message` component to display messages, if you want t
   #customMessageTemplate
   let-message="message"
   let-enabledMessageActions="enabledMessageActions"
-  let-areReactionsEnabled="areReactionsEnabled"
   let-canReactToMessage="canReactToMessage"
 >
   <app-custom-message
     [message]="message"
     [enabledMessageActions]="enabledMessageActions"
-    [areReactionsEnabled]="areReactionsEnabled"
     [canReactToMessage]="canReactToMessage"
   ></app-custom-message>
 </ng-template>
@@ -102,15 +100,17 @@ The `Message` component uses the [`Icon`](./icons.mdx) component to display icon
 
 ### enabledMessageActions
 
-The list of [actions that are enabled](./message-actions.mdx), please note that the user also has to have the necessary [channel capabilities](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript) for actions to work. Unathorized actions won't be displayed on the UI.
+The list of [channel capabilities](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript) that are enabled for the current user, the list of [supported interactions](../concepts/message-interactions.mdx) can be found in our message interaction guide. Unathorized actions won't be displayed on the UI.
 
-If you use the default chat UI you can also set this using the [`MessageList`](./message-list.mdx) component.
+The [`MessageList`](./message-list.mdx) component automatically sets this based on [channel capabilities](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript).
 
-| Type            |
-| --------------- |
-| MessageAction[] |
+| Type     |
+| -------- |
+| string[] |
 
-### areReactionsEnabled
+### <div class="label caution basic">Caution</div> areReactionsEnabled DEPRECATED
+
+**DEPRECATED** use [channel capabilities](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript) instead
 
 If true, the message reactions are displayed.
 
@@ -120,21 +120,25 @@ If you use the default chat UI you can also set this using the [`MessageList`](.
 | ------- |
 | boolean |
 
-### canReactToMessage
+### canReactToMessage DEPRECATED
+
+**DEPRECATED** use [channel capabilities](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript) instead
 
 If true, the user can add reactions to the message.
 
-If you use the default chat UI the [`MessageList`](./message-list.mdx) component automatically sets this based on [channel capability](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript).
+The [`MessageList`](./message-list.mdx) component automatically sets this based on [channel capability](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript).
 
 | Type   |
 | ------ |
 | boolen |
 
-### canReceiveReadEvents
+### canReceiveReadEvents DEPRECATED
+
+**DEPRECATED** use [channel capabilities](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript) instead
 
 If true, the read indicator is displayed.
 
-If you use the default chat UI the [`MessageList`](./message-list.mdx) component automatically sets this based on [channel capability](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript).
+The [`MessageList`](./message-list.mdx) component automatically sets this based on [channel capability](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript).
 
 | Type   |
 | ------ |

--- a/docusaurus/docs/Angular/concepts/message-interactions.mdx
+++ b/docusaurus/docs/Angular/concepts/message-interactions.mdx
@@ -1,0 +1,19 @@
+---
+id: message-interactions
+sidebar_position: 5
+title: Message interactions
+---
+
+Users can interact with the messages in the message list. The following table provides a list of possible interactions together with the [necessary capabilities](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript) and the corresponding components:
+
+| Description                                                                                          | Necessary channel capability             | Component                                                 |
+| ---------------------------------------------------------------------------------------------------- | ---------------------------------------- | --------------------------------------------------------- |
+| [Flags](https://getstream.io/chat/docs/javascript/moderation/?language=javascript) the given message | flag-message                             | [`MessageActionsBox`](../components/message-actions.mdx)  |
+| Edits a message that belongs to the user                                                             | update-own-message or update-any-message | [`MessageActionsBox`](../components/message-actions.mdx)  |
+| Edits any message                                                                                    | update-any-message                       | [`MessageActionsBox`](../components/message-actions.mdx)  |
+| Deletes a message that belongs to the user                                                           | delete-own-message or delete-any-message | [`MessageActionsBox`](../components/message-actions.mdx)  |
+| Deletes any message                                                                                  | delete-any-message                       | [`MessageActionsBox`](../components/message-actions.mdx)  |
+| Send reaction to a message                                                                           | send-reaction                            | [`MessageReactions`](../components/message-reactions.mdx) |
+| Receive read events                                                                                  | read-events                              | [`Message`](../components/message.mdx)                    |
+
+The [`MessageList`](../components/message-list.mdx) component authorizes the available interactions based on the [channel capabilities](https://getstream.io/chat/docs/javascript/channel_capabilities/?language=javascript) described above.

--- a/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.spec.ts
@@ -160,7 +160,7 @@ describe('MessageActionsBoxComponent', () => {
   });
 
   it(`should only display 'flag' action for other user's messages`, () => {
-    component.enabledActions = ['flag'];
+    component.enabledActions = ['flag-message'];
     component.isMine = false;
     fixture.detectChanges();
 
@@ -254,7 +254,12 @@ describe('MessageActionsBoxComponent', () => {
   });
 
   it('should emit the number of displayed actions', () => {
-    component.enabledActions = ['pin', 'edit', 'delete', 'flag'];
+    component.enabledActions = [
+      'pin',
+      'update-own-message',
+      'delete-own-message',
+      'flag',
+    ];
     component.isMine = true;
     const spy = jasmine.createSpy();
     component.displayedActionsCount.subscribe(spy);
@@ -269,7 +274,7 @@ describe('MessageActionsBoxComponent', () => {
     spy.calls.reset();
     component.enabledActions = [
       'pin',
-      'edit-any',
+      'update-any-message',
       'delete',
       'flag',
       'quote',
@@ -322,8 +327,8 @@ describe('MessageActionsBoxComponent', () => {
       expect(queryDeleteAction()).not.toBeNull();
     });
 
-    it('if #enabledActions contains "delete-any"', () => {
-      component.enabledActions = ['delete-any'];
+    it('if #enabledActions contains "delete-any-message"', () => {
+      component.enabledActions = ['delete-any-message'];
       component.isMine = false;
       fixture.detectChanges();
 

--- a/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts
+++ b/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts
@@ -14,6 +14,9 @@ import { MessageInputComponent } from '../message-input/message-input.component'
 import { NotificationService } from '../notification.service';
 import { StreamMessage } from '../types';
 
+/**
+ * @deprecated https://getstream.io/chat/docs/sdk/angular/components/message-actions/#required-enabledactions
+ */
 export type MessageActions =
   | 'edit'
   | 'delete'
@@ -34,7 +37,7 @@ export class MessageActionsBoxComponent implements OnChanges {
   @Input() isOpen = false;
   @Input() isMine = false;
   @Input() message: StreamMessage | undefined;
-  @Input() enabledActions: MessageActions[] = [];
+  @Input() enabledActions: string[] = [];
   @Output() readonly displayedActionsCount = new EventEmitter<number>();
   @Output() readonly isEditing = new EventEmitter<boolean>();
   isEditModalOpen = false;
@@ -79,15 +82,21 @@ export class MessageActionsBoxComponent implements OnChanges {
 
   get isEditVisible() {
     return (
-      (this.enabledActions.indexOf('edit') !== -1 && this.isMine) ||
-      this.enabledActions.indexOf('edit-any') !== -1
+      ((this.enabledActions.indexOf('edit') !== -1 ||
+        this.enabledActions.indexOf('update-own-message') !== -1) &&
+        this.isMine) ||
+      this.enabledActions.indexOf('edit-any') !== -1 ||
+      this.enabledActions.indexOf('update-any-message') !== -1
     );
   }
 
   get isDeleteVisible() {
     return (
-      (this.enabledActions.indexOf('delete') !== -1 && this.isMine) ||
-      this.enabledActions.indexOf('delete-any') !== -1
+      ((this.enabledActions.indexOf('delete') !== -1 ||
+        this.enabledActions.indexOf('delete-own-message') !== -1) &&
+        this.isMine) ||
+      this.enabledActions.indexOf('delete-any') !== -1 ||
+      this.enabledActions.indexOf('delete-any-message') !== -1
     );
   }
 
@@ -96,7 +105,11 @@ export class MessageActionsBoxComponent implements OnChanges {
   }
 
   get isFlagVisible() {
-    return this.enabledActions.indexOf('flag') !== -1 && !this.isMine;
+    return (
+      (this.enabledActions.indexOf('flag') !== -1 ||
+        this.enabledActions.indexOf('flag-message') !== -1) &&
+      !this.isMine
+    );
   }
 
   get isPinVisible() {

--- a/projects/stream-chat-angular/src/lib/message-list/message-list.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message-list/message-list.component.spec.ts
@@ -81,6 +81,7 @@ describe('MessageListComponent', () => {
       expect(m.areReactionsEnabled).toBe(component.areReactionsEnabled);
       expect(m.canReactToMessage).toBe(component.canReactToMessage);
       expect(m.enabledMessageActions).toEqual([
+        'send-reaction', // added automatically
         'flag',
         'edit',
         'edit-any',

--- a/projects/stream-chat-angular/src/lib/message/message.component.html
+++ b/projects/stream-chat-angular/src/lib/message/message.component.html
@@ -10,7 +10,7 @@
   [class.mobile-press]="isPressedOnMobile"
   [class.str-chat__message--has-attachment]="hasAttachment"
   [class.str-chat__message--with-reactions]="
-    areReactionsEnabled && hasReactions
+    areReactionsEnabled !== false && hasReactions
   "
   data-testid="message-container"
 >
@@ -29,7 +29,9 @@
         <ng-template #sentStatus>
           <ng-container
             *ngIf="
-              isMessageDeliveredAndRead && canReceiveReadEvents;
+              isMessageDeliveredAndRead &&
+                canReceiveReadEvents !== false &&
+                enabledMessageActions.indexOf('read-events') !== -1;
               else deliveredStatus
             "
           >
@@ -76,8 +78,13 @@
               (click)="isActionBoxOpen = !isActionBoxOpen"
             ></stream-icon>
           </div>
+          <!-- eslint-disable @angular-eslint/template/conditional-complexity -->
           <div
-            *ngIf="areReactionsEnabled && canReactToMessage"
+            *ngIf="
+              areReactionsEnabled !== false &&
+              canReactToMessage !== false &&
+              enabledMessageActions.indexOf('send-reaction') !== -1
+            "
             class="
               str-chat__message-simple__actions__action
               str-chat__message-simple__actions__action--reactions
@@ -89,8 +96,9 @@
             <stream-icon icon="reaction-icon"></stream-icon>
           </div>
         </div>
+        <!-- eslint-enable @angular-eslint/template/conditional-complexity -->
         <stream-message-reactions
-          *ngIf="areReactionsEnabled"
+          *ngIf="areReactionsEnabled !== false"
           [messageReactionCounts]="message?.reaction_counts || {}"
           [latestReactions]="message?.latest_reactions || []"
           [(isSelectorOpen)]="isReactionSelectorOpen"

--- a/projects/stream-chat-angular/src/lib/message/message.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message/message.component.spec.ts
@@ -118,9 +118,7 @@ describe('MessageComponent', () => {
       nativeElement.querySelector('[data-testid="message-deleted-component"]');
     querySystemMessageContainer = () =>
       nativeElement.querySelector('[data-testid="system-message"]');
-    component.areReactionsEnabled = true;
-    component.canReactToMessage = true;
-    component.canReceiveReadEvents = true;
+    component.enabledMessageActions = ['read-events', 'send-reaction'];
     fixture.detectChanges();
   });
 
@@ -215,7 +213,7 @@ describe('MessageComponent', () => {
 
     it(`should display delivered icon, if user can't receive delivered events`, () => {
       component.isLastSentMessage = true;
-      component.canReceiveReadEvents = false;
+      component.enabledMessageActions = [];
       fixture.detectChanges();
       const readIndicator = queryReadIndicator();
       const deliveredIndicator = queryDeliveredIndicator();
@@ -541,12 +539,12 @@ describe('MessageComponent', () => {
   it('should display reactions icon, if reactions are enabled and user can react to message', () => {
     expect(queryReactionIcon()).not.toBeNull();
 
-    component.canReactToMessage = false;
+    component.enabledMessageActions = [];
     fixture.detectChanges();
 
     expect(queryReactionIcon()).toBeNull();
 
-    component.canReactToMessage = true;
+    component.enabledMessageActions = ['send-reaction'];
     component.areReactionsEnabled = false;
     fixture.detectChanges();
 
@@ -580,7 +578,7 @@ describe('MessageComponent', () => {
         own_reactions: ownReactions,
       },
     };
-    component.canReactToMessage = true;
+    component.enabledMessageActions = ['send-reaction'];
     fixture.detectChanges();
     const messageReactionsComponent = queryMessageReactionsComponent();
 

--- a/projects/stream-chat-angular/src/lib/message/message.component.ts
+++ b/projects/stream-chat-angular/src/lib/message/message.component.ts
@@ -11,7 +11,6 @@ import { UserResponse } from 'stream-chat';
 import { ChannelService } from '../channel.service';
 import { ChatClientService } from '../chat-client.service';
 import { getDeviceWidth } from '../device-width';
-import { MessageActions } from '../message-actions-box/message-actions-box.component';
 import { DefaultUserType, StreamMessage } from '../types';
 import { parseDate } from './parse-date';
 import { getReadByText } from './read-by-text';
@@ -25,10 +24,19 @@ export class MessageComponent implements OnChanges {
   @Input() messageInputTemplate: TemplateRef<any> | undefined;
   @Input() mentionTemplate: TemplateRef<any> | undefined;
   @Input() message: StreamMessage | undefined;
-  @Input() enabledMessageActions: MessageActions[] = [];
+  @Input() enabledMessageActions: string[] = [];
+  /**
+   * @deprecated https://getstream.io/chat/docs/sdk/angular/components/message_list/#caution-arereactionsenabled-deprecated
+   */
   @Input() areReactionsEnabled: boolean | undefined;
+  /**
+   * @deprecated https://getstream.io/chat/docs/sdk/angular/components/message_list/#canreacttomessage-deprecated
+   */
   @Input() canReactToMessage: boolean | undefined;
   @Input() isLastSentMessage: boolean | undefined;
+  /**
+   * @deprecated https://getstream.io/chat/docs/sdk/angular/components/message_list/#canreceivereadevents-deprecated
+   */
   @Input() canReceiveReadEvents: boolean | undefined;
   isEditing: boolean | undefined;
   isActionBoxOpen = false;


### PR DESCRIPTION
In this PR:
- deprecated the inputs from the message list that can be set using channel capabilities
- combined all capability related inputs of the message component under the `enabledActions` input (old inputs are still working but deprecated)
- deprecated the SDK specific action names (like edit or delete) in favor of the capability names 