### PR TITLE
feat: Apply theme-v2 to channel list and preview #285

### DIFF
--- a/docusaurus/docs/Angular/concepts/theming-and-css.mdx
+++ b/docusaurus/docs/Angular/concepts/theming-and-css.mdx
@@ -10,7 +10,7 @@ import CustomLightThemeScreenshot from "../assets/custom-light-theme-screenshot.
 import CustomDarkThemeScreenshot from "../assets/custom-dark-theme-screenshot.png";
 
 :::caution
-This page contains information about the old theming system of the chat UI, this is now deprecated and will be removed in a future release. Please refere to our [new theming guide](../theming/introduction.mdx).
+This page contains information about the old theming system of the chat UI, this is now deprecated and will be removed in a future release. Please refer to our [new theming guide](../theming/introduction.mdx).
 :::
 
 ## Overriding CSS

--- a/docusaurus/docs/Angular/theming/component-variables.mdx
+++ b/docusaurus/docs/Angular/theming/component-variables.mdx
@@ -41,21 +41,26 @@ Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/style
 
 ## Channel preview
 
-| Name                                                         | Description                                                              |
-| ------------------------------------------------------------ | ------------------------------------------------------------------------ |
-| `--str-chat__channel-preview-font-family`                    | The font used in the component                                           |
-| `--str-chat__channel-preview-color`                          | The text/icon color of the the component                                 |
-| `--str-chat__channel-preview-background-color`               | The background color of the component                                    |
-| `--str-chat__channel-preview-border-radius`                  | The border radius used for the borders of the component                  |
-| `--str-chat__channel-preview-border-block-start`             | Top border of the component                                              |
-| `--str-chat__channel-preview-border-block-end`               | Bottom border of the component                                           |
-| `--str-chat__channel-preview-border-inline-start`            | Left (right in RTL layout) border of the component                       |
-| `--str-chat__channel-preview-border-inline-start`            | Right (lrft in RTL layout) border of the component                       |
-| `--str-chat__channel-preview-box-shadow`                     | Box shadow applied to the component                                      |
-| `--str-chat__channel-preview-active-background-color`        | Background color used for selected channel preview components            |
-| `--str-chat__channel-preview-hover-background-color`         | Background color used for the hover state                                |
-| `--str-chat__channel-preview-latest-message-secondary-color` | Text color of the latest message when preview is not hovered or selected |
-| `--str-chat__channel-preview-loading-state-color`            | The color of the loading indicator while initializing the channel list   |
+| Name                                                           | Description                                                              |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `--str-chat__channel-preview-font-family`                      | The font used in the component                                           |
+| `--str-chat__channel-preview-color`                            | The text/icon color of the the component                                 |
+| `--str-chat__channel-preview-background-color`                 | The background color of the component                                    |
+| `--str-chat__channel-preview-border-radius`                    | The border radius used for the borders of the component                  |
+| `--str-chat__channel-preview-border-block-start`               | Top border of the component                                              |
+| `--str-chat__channel-preview-border-block-end`                 | Bottom border of the component                                           |
+| `--str-chat__channel-preview-border-inline-start`              | Left (right in RTL layout) border of the component                       |
+| `--str-chat__channel-preview-border-inline-start`              | Right (lrft in RTL layout) border of the component                       |
+| `--str-chat__channel-preview-box-shadow`                       | Box shadow applied to the component                                      |
+| `--str-chat__channel-preview-active-background-color`          | Background color used for selected channel preview components            |
+| `--str-chat__channel-preview-hover-background-color`           | Background color used for the hover state                                |
+| `--str-chat__channel-preview-latest-message-secondary-color`   | Text color of the latest message when preview is not hovered or selected |
+| `--str-chat__channel-preview-loading-state-color`              | The color of the loading indicator while initializing the channel list   |
+| `--str-chat__channel-preview-unread-badge-border-radius`       | The border radius used for the borders of the unread badge               |
+| `--str-chat__channel-preview-unread-badge-border-block-start`  | Top border of the unread badge                                           |
+| `--str-chat__channel-preview-unread-badge-border-block-end`    | Bottom border of the unread badge                                        |
+| `--str-chat__channel-preview-unread-badge-border-inline-start` | Left (right in RTL layout) border of the unread badge                    |
+| `--str-chat__channel-preview-unread-badge-border-inline-start` | Right (lrft in RTL layout) border of the unread badge                    |
 
 Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/ChannelPreview/ChannelPreview-theme.scss](https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/ChannelPreview/ChannelPreview-theme.scss)
 

--- a/docusaurus/docs/Angular/theming/component-variables.mdx
+++ b/docusaurus/docs/Angular/theming/component-variables.mdx
@@ -13,17 +13,29 @@ This page contains information about the component variables.
 
 ## Channel list
 
-| Name                                           | Description                                             |
-| ---------------------------------------------- | ------------------------------------------------------- |
-| `--str-chat__channel-list-font-family`         | The font used in the component                          |
-| `--str-chat__channel-list-color`               | The text/icon color of the the component                |
-| `--str-chat__channel-list-background-color`    | The background color of the component                   |
-| `--str-chat__channel-list-border-radius`       | The border radius used for the borders of the component |
-| `--str-chat__channel-list-border-block-start`  | Top border of the component                             |
-| `--str-chat__channel-list-border-block-end`    | Bottom border of the component                          |
-| `--str-chat__channel-list-border-inline-start` | Left (right in RTL layout) border of the component      |
-| `--str-chat__channel-list-border-inline-start` | Right (lrft in RTL layout) border of the component      |
-| `--str-chat__channel-list-box-shadow`          | Box shadow applied to the component                     |
+| Name                                                           | Description                                                    |
+| -------------------------------------------------------------- | -------------------------------------------------------------- |
+| `--str-chat__channel-list-font-family`                         | The font used in the component                                 |
+| `--str-chat__channel-list-color`                               | The text/icon color of the component                           |
+| `--str-chat__channel-list-background-color`                    | The background color of the component                          |
+| `--str-chat__channel-list-border-radius`                       | The border radius used for the borders of the component        |
+| `--str-chat__channel-list-border-block-start`                  | Top border of the component                                    |
+| `--str-chat__channel-list-border-block-end`                    | Bottom border of the component                                 |
+| `--str-chat__channel-list-border-inline-start`                 | Left (right in RTL layout) border of the component             |
+| `--str-chat__channel-list-border-inline-start`                 | Right (lrft in RTL layout) border of the component             |
+| `--str-chat__channel-list-box-shadow`                          | Box shadow applied to the component                            |
+| `--str-chat__channel-list-load-more-font-family`               | The font used for the load more button                         |
+| `--str-chat__channel-list-load-more-color`                     | The text/icon color of the load more button                    |
+| `--str-chat__channel-list-load-more-background-color`          | The background color of the load more button                   |
+| `--str-chat__channel-list-load-more-border-radius`             | The border radius used for the borders of the load more button |
+| `--str-chat__channel-list-load-more-border-block-start`        | Top border of the load more button                             |
+| `--str-chat__channel-list-load-more-border-block-end`          | Bottom border of the load more button                          |
+| `--str-chat__channel-list-load-more-border-inline-start`       | Left (right in RTL layout) border of the load more button      |
+| `--str-chat__channel-list-load-more-border-inline-start`       | Right (lrft in RTL layout) border of the load more button      |
+| `--str-chat__channel-list-load-more-box-shadow`                | Box shadow applied to the load more button                     |
+| `--str-chat__channel-list-load-more-pressed-background-color`  | The background color of the load more button in pressed state  |
+| `--str-chat__channel-list-load-more-disabled-background-color` | The background color of the load more button in disabled state |
+| `--str-chat__channel-list-load-more-disabled-color`            | The text/icon color of the load more button in disabled state  |
 
 Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/ChannelList/ChannelList-theme.scss](https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/ChannelList/ChannelList-theme.scss)
 
@@ -43,6 +55,7 @@ Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/style
 | `--str-chat__channel-preview-active-background-color`        | Background color used for selected channel preview components            |
 | `--str-chat__channel-preview-hover-background-color`         | Background color used for the hover state                                |
 | `--str-chat__channel-preview-latest-message-secondary-color` | Text color of the latest message when preview is not hovered or selected |
+| `--str-chat__channel-preview-loading-state-color`            | The color of the loading indicator while initializing the channel list   |
 
 Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/ChannelPreview/ChannelPreview-theme.scss](https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/ChannelPreview/ChannelPreview-theme.scss)
 
@@ -61,3 +74,34 @@ Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/style
 | `--str-chat__avatar-box-shadow`          | Box shadow applied to the component                     |
 
 Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/Avatar/Avatar-theme.scss](https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/Avatar/Avatar-theme.scss)
+
+## Loading indicator
+
+| Name                                  | Description                                                |
+| ------------------------------------- | ---------------------------------------------------------- |
+| `--str-chat__loading-indicator-color` | Color of the spinner used to display the loading indicator |
+
+## Call-to-action button
+
+This is a generic component used to display action buttons.
+
+Call-to-actions buttons: channel list load more button
+
+You can override the following variables if you want to adjust the style of all call-to-action buttons in the chat UI
+
+| Name                                               | Description                                          |
+| -------------------------------------------------- | ---------------------------------------------------- |
+| `--str-chat__cta-button-font-family`               | The font used for the button                         |
+| `--str-chat__cta-button-color`                     | The text/icon color of the button                    |
+| `--str-chat__cta-button-background-color`          | The background color of the button                   |
+| `--str-chat__cta-button-border-radius`             | The border radius used for the borders of the button |
+| `--str-chat__cta-button-border-block-start`        | Top border of the button                             |
+| `--str-chat__cta-button-border-block-end`          | Bottom border of the button                          |
+| `--str-chat__cta-button-border-inline-start`       | Left (right in RTL layout) border of the button      |
+| `--str-chat__cta-button-border-inline-start`       | Right (lrft in RTL layout) border of the button      |
+| `--str-chat__cta-button-more-box-shadow`           | Box shadow applied to the button                     |
+| `--str-chat__cta-button-pressed-background-color`  | The background color of the button in pressed state  |
+| `--str-chat__cta-button-disabled-background-color` | The background color of the button in disabled state |
+| `--str-chat__cta-button-disabled-color`            | The text/icon color of the button in disabled state  |
+
+Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/common/CTAButton/CTAButton-theme.scss](https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/common/CTAButton/CTAButton-theme.scss)

--- a/docusaurus/docs/Angular/theming/component-variables.mdx
+++ b/docusaurus/docs/Angular/theming/component-variables.mdx
@@ -36,6 +36,7 @@ This page contains information about the component variables.
 | `--str-chat__channel-list-load-more-pressed-background-color`  | The background color of the load more button in pressed state  |
 | `--str-chat__channel-list-load-more-disabled-background-color` | The background color of the load more button in disabled state |
 | `--str-chat__channel-list-load-more-disabled-color`            | The text/icon color of the load more button in disabled state  |
+| `--str-chat__channel-list-empty-indicator-color`               | The icon color for the empty list state                        |
 
 Defined in: [https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/ChannelList/ChannelList-theme.scss](https://github.com/GetStream/stream-chat-css/blob/main/src-v2/styles/ChannelList/ChannelList-theme.scss)
 

--- a/docusaurus/docs/Angular/theming/theme-variables.mdx
+++ b/docusaurus/docs/Angular/theming/theme-variables.mdx
@@ -35,6 +35,8 @@ You can read about each category in detail in the tables below.
 | `--str-chat__text-low-emphasis-color`    | Used for texts/icons that need less emphasis                                         | The latest message in the channel preview, deleted message text, default icon state, etc. |
 | `--str-chat__disabled-color`             | Used for displaying disabled UI elements (typically buttons)                         | Disabled send button etc.                                                                 |
 | `--str-chat__on-disabled-color`          | Used for text/icon colors if disabled color is used as a background color            | Text on disabled send button etc.                                                         |
+| `--str-chat__unread-badge-color`         | Used for displaying the unread badge                                                 | Background of the unread badge                                                            |
+| `--str-chat__on-unread-badge-color`      | Used for text/icon colors if unread badge color is used as a background color        | Text on the unread badge                                                                  |
 | `--str-chat__danger-color`               | Used for error messages, and destructive actions                                     | Delete action label etc.                                                                  |
 | `--str-chat__overlay-color`              | The background color used for modal overlays                                         | Modal overlay color                                                                       |
 

--- a/docusaurus/docs/Angular/theming/theme-variables.mdx
+++ b/docusaurus/docs/Angular/theming/theme-variables.mdx
@@ -4,12 +4,7 @@ sidebar_position: 2
 title: Theme variables
 ---
 
-<<<<<<< HEAD
 CSS variables are the easiest way to customize the theme. The variables are organized into two layers:
-=======
-CSS variables are the easieast way for customizing the theme. The variables are organized into two layers:
-
-> > > > > > > 9ac0f61 (docs: Document theme and component layer variables #289)
 
 - Theme
 - Component

--- a/docusaurus/docs/Angular/theming/theme-variables.mdx
+++ b/docusaurus/docs/Angular/theming/theme-variables.mdx
@@ -4,7 +4,12 @@ sidebar_position: 2
 title: Theme variables
 ---
 
+<<<<<<< HEAD
 CSS variables are the easiest way to customize the theme. The variables are organized into two layers:
+=======
+CSS variables are the easieast way for customizing the theme. The variables are organized into two layers:
+
+> > > > > > > 9ac0f61 (docs: Document theme and component layer variables #289)
 
 - Theme
 - Component

--- a/projects/sample-app/src/app/app.component.scss
+++ b/projects/sample-app/src/app/app.component.scss
@@ -3,11 +3,22 @@
   height: 100%;
 
   .channel-list {
-    width: 25%;
+    width: 100%;
     height: 100%;
   }
 
   .channel {
-    width: 75%;
+    width: 100%;
+  }
+
+  @media screen and (min-width: 768px) {
+    .channel-list {
+      width: 35%;
+      height: 100%;
+    }
+
+    .channel {
+      width: 65%;
+    }
   }
 }

--- a/projects/stream-chat-angular/src/lib/channel-list/channel-list.component.html
+++ b/projects/stream-chat-angular/src/lib/channel-list/channel-list.component.html
@@ -1,7 +1,8 @@
 <div
   #container
   data-testid="channel-list-container"
-  class="str-chat str-chat-channel-list messaging str-chat__theme-{{
+  style="max-width: unset"
+  class="str-chat str-chat__channel-list str-chat-channel-list messaging str-chat__theme-{{
     theme$ | async
   }}"
   [class.str-chat-channel-list--open]="(isOpen$ | async) === true"
@@ -14,9 +15,19 @@
     class="str-chat__channel-list-messenger"
   >
     <div class="str-chat__channel-list-messenger__main">
-      <p
-        data-testid="empty-channel-list-indicator"
+      <div
+        class="str-chat__channel-list-empty"
         *ngIf="!(channels$ | async)?.length"
+      >
+        <stream-icon icon="chat-bubble"></stream-icon>
+        <p data-testid="empty-channel-list-indicator">
+          {{ "streamChat.You have no channels currently" | translate }}
+        </p>
+      </div>
+      <p
+        *ngIf="!(channels$ | async)?.length"
+        class="str-chat__channel-list-empty-v1"
+        data-testid="empty-channel-list-indicator"
       >
         {{ "streamChat.You have no channels currently" | translate }}
       </p>

--- a/projects/stream-chat-angular/src/lib/channel-list/channel-list.component.html
+++ b/projects/stream-chat-angular/src/lib/channel-list/channel-list.component.html
@@ -46,7 +46,7 @@
         data-testid="load-more"
       >
         <button
-          class="str-chat__load-more-button__button"
+          class="str-chat__load-more-button__button str-chat__cta-button"
           data-testid="load-more-button"
           [disabled]="isLoadingMoreChannels"
         >
@@ -98,9 +98,15 @@
 </ng-template>
 
 <ng-template #loadingChannel>
-  <div class="str-chat__loading-channels-item">
+  <div
+    class="str-chat__loading-channels-item str-chat__channel-preview-loading"
+  >
     <div class="str-chat__loading-channels-avatar"></div>
-    <div class="str-chat__loading-channels-meta">
+    <div
+      class="
+        str-chat__loading-channels-meta str-chat__channel-preview-end-loading
+      "
+    >
       <div class="str-chat__loading-channels-username"></div>
       <div class="str-chat__loading-channels-status"></div>
     </div>

--- a/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.html
+++ b/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.html
@@ -3,7 +3,6 @@
   [class.str-chat__channel-preview-messenger--active]="isActive"
   [class.str-chat__channel-preview--active]="isActive"
   [class.str-chat__channel-preview-messenger--unread]="isUnread"
-  [class.str-chat__channel-preview--unread]="isUnread"
   (click)="setAsActiveChannel()"
   data-testid="channel-preview-container"
 >
@@ -22,11 +21,17 @@
       str-chat__channel-preview-messenger--right str-chat__channel-preview-end
     "
   >
-    <div
-      style="position: relative"
-      class="str-chat__channel-preview-messenger--name"
-    >
-      <span data-testid="channel-preview-title">{{ title }}</span>
+    <div class="str-chat__channel-preview-end-first-row">
+      <div class="str-chat__channel-preview-messenger--name">
+        <span data-testid="channel-preview-title">{{ title }}</span>
+      </div>
+      <div
+        data-testid="unread-badge"
+        *ngIf="unreadCount"
+        class="str-chat__channel-preview-unread-badge"
+      >
+        {{ unreadCount }}
+      </div>
     </div>
     <div
       data-testid="latest-message"

--- a/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.html
+++ b/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.html
@@ -3,6 +3,7 @@
   [class.str-chat__channel-preview-messenger--active]="isActive"
   [class.str-chat__channel-preview--active]="isActive"
   [class.str-chat__channel-preview-messenger--unread]="isUnread"
+  [class.str-chat__channel-preview--unread]="isUnread"
   (click)="setAsActiveChannel()"
   data-testid="channel-preview-container"
 >

--- a/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.spec.ts
@@ -145,6 +145,20 @@ describe('ChannelPreviewComponent', () => {
     expect(queryUnreadBadge()).toBeNull();
   });
 
+  it(`shouldn't set unread state for active channels`, () => {
+    const channels = generateMockChannels();
+    const channel = channels[0];
+    const countUnreadSpy = spyOn(channel, 'countUnread');
+    countUnreadSpy.and.returnValue(1);
+    component.channel = channel;
+    channelServiceMock.activeChannel$.next(channel);
+    component.channel = channel;
+    component.ngOnInit();
+
+    expect(component.isUnread).toBe(false);
+    expect(component.unreadCount).toBe(0);
+  });
+
   it('should set channel as active', () => {
     const channel = generateMockChannels()[0];
     component.channel = channel;

--- a/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.spec.ts
@@ -26,6 +26,7 @@ describe('ChannelPreviewComponent', () => {
   let queryAvatar: () => AvatarPlaceholderComponent;
   let queryTitle: () => HTMLElement | null;
   let queryLatestMessage: () => HTMLElement | null;
+  let queryUnreadBadge: () => HTMLElement | null;
 
   beforeEach(() => {
     channelServiceMock = mockChannelService();
@@ -56,6 +57,8 @@ describe('ChannelPreviewComponent', () => {
         .componentInstance as AvatarPlaceholderComponent;
     queryLatestMessage = () =>
       nativeElement.querySelector('[data-testid="latest-message"]');
+    queryUnreadBadge = () =>
+      nativeElement.querySelector('[data-testid="unread-badge"]');
   });
 
   it('should apply active class if channel is active', () => {
@@ -80,7 +83,7 @@ describe('ChannelPreviewComponent', () => {
     expect(queryContainer()?.classList.contains(activeClass)).toBeFalse();
   });
 
-  it('should apply unread class, if channel has unread messages', () => {
+  it('should apply unread class and display unread badge, if channel has unread messages', () => {
     const channels = generateMockChannels();
     const channel = channels[0];
     component.channel = channel;
@@ -91,6 +94,7 @@ describe('ChannelPreviewComponent', () => {
     fixture.detectChanges();
 
     expect(container?.classList.contains(unreadClass)).toBeFalse();
+    expect(queryUnreadBadge()).toBeNull();
 
     countUnreadSpy.and.returnValue(1);
     const newMessage = mockMessage();
@@ -99,6 +103,8 @@ describe('ChannelPreviewComponent', () => {
     fixture.detectChanges();
 
     expect(container?.classList.contains(unreadClass)).toBeTrue();
+    expect(component.unreadCount).toBe(1);
+    expect(queryUnreadBadge()?.innerHTML).toContain('1');
   });
 
   it(`shouldn't apply unread class, if user doesn't have 'read-events' capabilities`, () => {
@@ -114,25 +120,29 @@ describe('ChannelPreviewComponent', () => {
     fixture.detectChanges();
 
     expect(container?.classList.contains(unreadClass)).toBeFalse();
+    expect(queryUnreadBadge()).toBeNull();
   });
 
-  it('should remove unread class, if user marked channel as read', () => {
+  it('should remove unread class and badge, if user marked channel as read', () => {
     const channels = generateMockChannels();
     const channel = channels[0];
     component.channel = channel;
-    let undreadCount = 1;
+    let undreadCount = 3;
     spyOn(channel, 'countUnread').and.callFake(() => undreadCount);
     const unreadClass = 'str-chat__channel-preview-messenger--unread';
     const container = queryContainer();
     fixture.detectChanges();
 
     expect(container?.classList.contains(unreadClass)).toBeTrue();
+    expect(component.unreadCount).toBe(3);
+    expect(queryUnreadBadge()?.innerHTML).toContain('3');
 
     undreadCount = 0;
     channel.handleEvent('message.read', {});
     fixture.detectChanges();
 
     expect(container?.classList.contains(unreadClass)).toBeFalse();
+    expect(queryUnreadBadge()).toBeNull();
   });
 
   it('should set channel as active', () => {

--- a/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.ts
+++ b/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.ts
@@ -26,6 +26,7 @@ export class ChannelPreviewComponent implements OnInit, OnDestroy {
   @Input() channel: Channel<DefaultStreamChatGenerics> | undefined;
   isActive = false;
   isUnread = false;
+  unreadCount: number | undefined;
   latestMessage: string = 'streamChat.Nothing yet...';
   private subscriptions: (Subscription | { unsubscribe: () => void })[] = [];
   private canSendReadEvents = true;
@@ -47,7 +48,7 @@ export class ChannelPreviewComponent implements OnInit, OnDestroy {
     if (messages && messages.length > 0) {
       this.setLatestMessage(messages[messages.length - 1]);
     }
-    this.isUnread = !!this.channel!.countUnread() && this.canSendReadEvents;
+    this.updateUnreadState();
     const capabilities =
       (this.channel?.data?.own_capabilities as string[]) || [];
     this.canSendReadEvents = capabilities.indexOf('read-events') !== -1;
@@ -66,8 +67,7 @@ export class ChannelPreviewComponent implements OnInit, OnDestroy {
     this.subscriptions.push(
       this.channel!.on('message.read', () =>
         this.ngZone.run(() => {
-          this.isUnread =
-            !!this.channel!.countUnread() && this.canSendReadEvents;
+          this.updateUnreadState();
         })
       )
     );
@@ -113,7 +113,7 @@ export class ChannelPreviewComponent implements OnInit, OnDestroy {
         return;
       }
       this.setLatestMessage(event.message);
-      this.isUnread = !!this.channel.countUnread() && this.canSendReadEvents;
+      this.updateUnreadState();
     });
   }
 
@@ -124,6 +124,16 @@ export class ChannelPreviewComponent implements OnInit, OnDestroy {
       this.latestMessage = message.text;
     } else if (message?.attachments && message.attachments.length) {
       this.latestMessage = 'streamChat.🏙 Attachment...';
+    }
+  }
+
+  private updateUnreadState() {
+    if (this.canSendReadEvents) {
+      this.unreadCount = this.channel!.countUnread();
+      this.isUnread = !!this.unreadCount;
+    } else {
+      this.unreadCount = undefined;
+      this.isUnread = false;
     }
   }
 }

--- a/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.ts
+++ b/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.ts
@@ -128,12 +128,12 @@ export class ChannelPreviewComponent implements OnInit, OnDestroy {
   }
 
   private updateUnreadState() {
-    if (this.canSendReadEvents) {
-      this.unreadCount = this.channel!.countUnread();
-      this.isUnread = !!this.unreadCount;
-    } else {
-      this.unreadCount = undefined;
+    if (this.isActive || !this.canSendReadEvents) {
+      this.unreadCount = 0;
       this.isUnread = false;
+      return;
     }
+    this.unreadCount = this.channel!.countUnread();
+    this.isUnread = !!this.unreadCount;
   }
 }

--- a/projects/stream-chat-angular/src/lib/icon/icon.component.html
+++ b/projects/stream-chat-angular/src/lib/icon/icon.component.html
@@ -283,3 +283,15 @@
     fill="var(--primary-color)"
   />
 </svg>
+<svg
+  data-testid="chat-bubble"
+  *ngIf="icon === 'chat-bubble'"
+  viewBox="0 0 136 136"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M106 24.5H30C24.775 24.5 20.5 28.775 20.5 34V119.5L39.5 100.5H106C111.225 100.5 115.5 96.225 115.5 91V34C115.5 28.775 111.225 24.5 106 24.5ZM106 91H39.5L30 100.5V34H106V91Z"
+    fill="#B4B7BB"
+  />
+</svg>

--- a/projects/stream-chat-angular/src/lib/icon/icon.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/icon/icon.component.spec.ts
@@ -138,6 +138,13 @@ describe('IconComponent', () => {
     expect(queryIcon('arrow-down')).not.toBeNull();
   });
 
+  it('should display chat-bubble icon', () => {
+    component.icon = 'chat-bubble';
+    fixture.detectChanges();
+
+    expect(queryIcon('chat-bubble')).not.toBeNull();
+  });
+
   it('should not display anything if #icon is not provided', () => {
     expect(nativeElement.innerHTML).not.toContain('svg');
   });

--- a/projects/stream-chat-angular/src/lib/icon/icon.component.ts
+++ b/projects/stream-chat-angular/src/lib/icon/icon.component.ts
@@ -17,7 +17,8 @@ export type Icon =
   | 'arrow-right'
   | 'menu'
   | 'arrow-up'
-  | 'arrow-down';
+  | 'arrow-down'
+  | 'chat-bubble';
 
 /**
  * The `Icon` component can be used to display different icons (i. e. message delivered icon).

--- a/projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.spec.ts
@@ -32,7 +32,9 @@ describe('LoadingIndicatorPlaceholderComponent', () => {
       By.directive(LoadingIndicatorComponent)
     ).componentInstance as LoadingIndicatorComponent;
 
-    expect(loadingIndicatorComponent.color).toBe('#006CFF');
+    expect(loadingIndicatorComponent.color).toBe(
+      `var(--str-chat__loading-indicator-color, var(--str-chat__primary-color, '#006CFF'))`
+    );
     expect(loadingIndicatorComponent.size).toBe(15);
 
     component.color = 'red';

--- a/projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.spec.ts
@@ -35,6 +35,7 @@ describe('LoadingIndicatorPlaceholderComponent', () => {
     expect(loadingIndicatorComponent.color).toBe(
       `var(--str-chat__loading-indicator-color, var(--str-chat__primary-color, '#006CFF'))`
     );
+
     expect(loadingIndicatorComponent.size).toBe(15);
 
     component.color = 'red';

--- a/projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.ts
+++ b/projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.ts
@@ -18,7 +18,9 @@ export class LoadingIndicatorPlaceholderComponent {
   /**
    * The color of the indicator
    */
-  @Input() color = '#006CFF';
+  @Input()
+  color = `var(--str-chat__loading-indicator-color, var(--str-chat__primary-color, '#006CFF'))`;
+
   constructor(public customTemplatesService: CustomTemplatesService) {}
 
   getLoadingIndicatorContext(): LoadingIndicatorContext {

--- a/projects/stream-chat-angular/src/lib/loading-indicator/loading-indicator.component.ts
+++ b/projects/stream-chat-angular/src/lib/loading-indicator/loading-indicator.component.ts
@@ -16,7 +16,8 @@ export class LoadingIndicatorComponent {
   /**
    * The color of the indicator
    */
-  @Input() color = '#006CFF';
+  @Input()
+  color = `var(--str-chat__loading-indicator-color, var(--str-chat__primary-color, '#006CFF'))`;
 
   constructor() {}
 }


### PR DESCRIPTION
There are some differences between Figma and implementations, the main reasons:
- Figma has features that are not supported by (Angular) SDK
- We try not to modify the HTML markup to be compatible with theme-v1

No screenshots for responsive layout, that will added to the sample app in this issue: https://github.com/GetStream/stream-chat-angular/issues/284

| Figma  | Implementation |  Remark |
| ------------- | ------------- |------------- |
|   <img width="258" alt="Screenshot 2022-05-16 at 10 23 38" src="https://user-images.githubusercontent.com/6690098/168550674-0da27d0b-db9a-400a-a624-c4b9c46ee3f2.png">| <img width="258" alt="Screenshot 2022-05-13 at 12 43 49" src="https://user-images.githubusercontent.com/6690098/168550798-33d22ab3-3c84-4f0a-9535-4e8124e907f0.png"> | Selected state: "Testing" channel, hover state: "zitasuperagetstreamio" channel, Unread channel: "Talking about Christmas" (Figma has the unread badge for this, but Angualr SDK doesn't have unread badge)
| <img width="261" alt="Screenshot 2022-05-16 at 10 23 47" src="https://user-images.githubusercontent.com/6690098/168551752-5eb44fde-cf84-4fd7-a616-fed47d84e4d1.png"> | <img width="355" alt="Screenshot 2022-05-13 at 12 42 01" src="https://user-images.githubusercontent.com/6690098/168551791-1df2e9b7-ce70-411f-a82a-3b17a2331f56.png"> 
| <img width="221" alt="Screenshot 2022-05-16 at 10 24 03" src="https://user-images.githubusercontent.com/6690098/168551908-ac01de3e-7c2d-45ec-bedd-671ae47bea8f.png"> | <img width="334" alt="Screenshot 2022-05-12 at 13 48 15" src="https://user-images.githubusercontent.com/6690098/168551956-c1810a7a-0767-4e29-9c5f-11fc3a30324f.png"> | Animation added for UX purposes, only 3 item displayed instead of filling the whole list to not to have to update markup |
| <img width="219" alt="Screenshot 2022-05-16 at 10 24 09" src="https://user-images.githubusercontent.com/6690098/168552388-b998cd90-cc5c-4a26-982f-7d0a5a955cc9.png"> | <img width="327" alt="Screenshot 2022-05-12 at 13 49 08" src="https://user-images.githubusercontent.com/6690098/168552412-607b55e1-8141-4122-a4fd-6d1cb711f9b6.png"> |
| Figma has no Load more button for channel list | <img width="356" alt="Screenshot 2022-05-13 at 12 29 19" src="https://user-images.githubusercontent.com/6690098/168552550-66524449-4b33-4ba0-be19-fffbcaa1c833.png"> | We plan to remove the load more button from the SDKs and use infinite scroll instead - so this screen will be removed in the long term |
| Figma has no Load more button for channel list | <img width="353" alt="Screenshot 2022-05-13 at 12 33 08" src="https://user-images.githubusercontent.com/6690098/168552711-e0e58577-0d9d-4256-9852-bae4a45b08ef.png">
| Figma has no Load more button for channel list  | <img width="354" alt="Screenshot 2022-05-13 at 12 31 36" src="https://user-images.githubusercontent.com/6690098/168552860-560e8f3f-61f2-415d-a07a-26ca46819f1b.png"> | Loading more channels |
| Figma has no Load more button for channel list | <img width="350" alt="Screenshot 2022-05-13 at 12 32 19" src="https://user-images.githubusercontent.com/6690098/168553024-79c74c77-8f20-4b1c-bdcf-b58f52d34bf3.png"> |
| <img width="300" alt="Screenshot 2022-05-16 at 10 24 32" src="https://user-images.githubusercontent.com/6690098/168553296-d170478c-9731-4c68-a2cd-cd886136e7d9.png"> | - | Error notifications will be implemented in: https://github.com/GetStream/stream-chat-angular/issues/277


I'll also ask for approvement from Fra for the design implementation

closes #285 