### PR TITLE
feat: Message reactions #279

### DIFF
--- a/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.html
+++ b/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.html
@@ -1,21 +1,34 @@
 <div
-  *ngIf="existingReactions.length > 0 && !isSelectorOpen"
-  class="str-chat__reaction-list"
+  *ngIf="existingReactions.length > 0"
+  class="str-chat__reaction-list str-chat__message-reactions-container"
   [class.str-chat__reaction-list--reverse]="true"
+  [class.str-chat__reaction-list-hidden]="isSelectorOpen"
   data-testid="reaction-list"
 >
-  <ul>
+  <ul class="str-chat__message-reactions">
     <li
+      class="str-chat__message-reaction"
       *ngFor="
         let reactionType of existingReactions;
         trackBy: trackByMessageReaction
       "
+      [class.str-chat__message-reaction-own]="isOwnReaction(reactionType)"
       data-testclass="emoji"
     >
-      <span class="emoji">
-        {{ getEmojiByReaction(reactionType) }}
+      <div data-testclass="tooltip" class="str-chat__tooltip">
+        <span>
+          {{ getUsersByReaction(reactionType) }}
+        </span>
+      </div>
+      <span class="emoji str-chat__message-reaction-emoji">
+        {{ getEmojiByReaction(reactionType) }}&nbsp;
       </span>
-      &nbsp;
+      <span
+        data-testclass="reaction-list-reaction-count"
+        class="str-chat__message-reaction-count"
+      >
+        {{ messageReactionCounts[reactionType] }}
+      </span>
     </li>
     <li>
       <span
@@ -29,7 +42,7 @@
 
 <div
   #selectorContainer
-  class="str-chat__reaction-selector"
+  class="str-chat__reaction-selector str-chat__message-reaction-selector"
   *ngIf="isSelectorOpen"
   data-testid="reaction-selector"
 >
@@ -51,12 +64,21 @@
       {{ tooltipText }}
     </span>
   </div>
-  <ul class="str-chat__message-reactions-list">
+  <ul
+    class="str-chat__message-reactions-list str-chat__message-reactions-options"
+  >
     <li
-      class="str-chat__message-reactions-list-item str-chat__emoji"
+      class="
+        str-chat__message-reactions-option
+        str-chat__message-reactions-list-item
+        str-chat__emoji
+      "
       *ngFor="
         let reactionType of reactionOptions;
         trackBy: trackByMessageReaction
+      "
+      [class.str-chat__message-reactions-option-selected]="
+        isOwnReaction(reactionType)
       "
       data-testclass="emoji-option"
       (click)="react(reactionType)"
@@ -64,7 +86,7 @@
     >
       <div
         *ngIf="getLatestUserByReaction(reactionType) as user"
-        class="latest-user"
+        class="latest-user str-chat__message-reactions-last-user"
         (click)="hideTooltip()"
         (keyup.enter)="hideTooltip()"
         (mouseenter)="showTooltip($event, reactionType)"
@@ -78,7 +100,13 @@
           [size]="20"
         ></stream-avatar-placeholder>
       </div>
-      <span class="emoji" style="width: 20px; height: 20px; top: 10px">
+      <span
+        class="
+          emoji
+          str-chat__emoji-selector-emoji-angular
+          str-chat__message-reaction-emoji
+        "
+      >
         {{ getEmojiByReaction(reactionType) }}
       </span>
       <span

--- a/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts
+++ b/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts
@@ -142,6 +142,10 @@ export class MessageReactionsComponent implements AfterViewChecked, OnChanges {
       : void this.channelService.addReaction(this.messageId!, type);
   }
 
+  isOwnReaction(reactionType: MessageReactionType) {
+    return !!this.ownReactions.find((r) => r.type === reactionType);
+  }
+
   private eventHandler = (event: Event) => {
     if (!this.selectorContainer?.nativeElement.contains(event.target as Node)) {
       this.isSelectorOpenChange.emit(false);

--- a/projects/stream-chat-angular/src/lib/message/message.component.html
+++ b/projects/stream-chat-angular/src/lib/message/message.component.html
@@ -119,31 +119,33 @@
             ></stream-icon-placeholder>
           </div>
         </div>
-        <!-- eslint-enable @angular-eslint/template/conditional-complexity -->
-        <ng-template
-          #defaultMessageReactions
-          let-messageReactionCounts="messageReactionCounts"
-          let-latestReactions="latestReactions"
-          let-isSelectorOpen="isSelectorOpen"
-          let-isSelectorOpenChangeHandler="isSelectorOpenChangeHandler"
-          let-messageId="messageId"
-          let-ownReactions="ownReactions"
-        >
-          <stream-message-reactions
-            [messageReactionCounts]="messageReactionCounts"
-            [latestReactions]="latestReactions"
-            [isSelectorOpen]="isSelectorOpen"
-            (isSelectorOpenChange)="isSelectorOpenChangeHandler($event)"
-            [messageId]="messageId"
-            [ownReactions]="ownReactions"
-          ></stream-message-reactions>
-        </ng-template>
-        <ng-container
-          *ngTemplateOutlet="
-            messageReactionsTemplate || defaultMessageReactions;
-            context: getMessageReactionsContext()
-          "
-        ></ng-container>
+        <div class="str-chat__message-reactions-host">
+          <!-- eslint-enable @angular-eslint/template/conditional-complexity -->
+          <ng-template
+            #defaultMessageReactions
+            let-messageReactionCounts="messageReactionCounts"
+            let-latestReactions="latestReactions"
+            let-isSelectorOpen="isSelectorOpen"
+            let-isSelectorOpenChangeHandler="isSelectorOpenChangeHandler"
+            let-messageId="messageId"
+            let-ownReactions="ownReactions"
+          >
+            <stream-message-reactions
+              [messageReactionCounts]="messageReactionCounts"
+              [latestReactions]="latestReactions"
+              [isSelectorOpen]="isSelectorOpen"
+              (isSelectorOpenChange)="isSelectorOpenChangeHandler($event)"
+              [messageId]="messageId"
+              [ownReactions]="ownReactions"
+            ></stream-message-reactions>
+          </ng-template>
+          <ng-container
+            *ngTemplateOutlet="
+              messageReactionsTemplate || defaultMessageReactions;
+              context: getMessageReactionsContext()
+            "
+          ></ng-container>
+        </div>
         <div class="str-chat__message-bubble">
           <ng-container *ngIf="hasAttachment && !message?.quoted_message">
             <ng-template


### PR DESCRIPTION
closes #279 

# Figma
(simplified version)
![Screenshot 2022-06-15 at 11 39 59](https://user-images.githubusercontent.com/6690098/173796660-fcac0a27-f432-4d92-ac29-38eb58cf9e07.png)
![Screenshot 2022-06-15 at 11 40 21](https://user-images.githubusercontent.com/6690098/173796740-f8cfdccc-3433-4713-89ea-a9761601a278.png)
![Screenshot 2022-06-15 at 11 41 32](https://user-images.githubusercontent.com/6690098/173796995-3e29538b-19d0-41cf-b352-4b4ebbbcf4bf.png)

# Implementation

![Screenshot 2022-06-15 at 10 46 41](https://user-images.githubusercontent.com/6690098/173797046-0c3213e6-f85c-4260-bbb1-25fb7628918e.png)
![Screenshot 2022-06-15 at 10 46 54](https://user-images.githubusercontent.com/6690098/173797071-432cbe1a-5637-45dc-a956-b9230b4e02d0.png)
![Screenshot 2022-06-15 at 11 49 56](https://user-images.githubusercontent.com/6690098/173798848-a1690441-e989-4712-a1df-6b25b268e0da.png)
![Screenshot 2022-06-15 at 10 46 48](https://user-images.githubusercontent.com/6690098/173797063-952976ca-299c-4c45-b6d3-ec8a805b3216.png)
![Screenshot 2022-06-15 at 10 49 42](https://user-images.githubusercontent.com/6690098/173797078-c4d18a71-9fe3-4854-9064-4f34f3bc5118.png)
![Screenshot 2022-06-15 at 10 49 53](https://user-images.githubusercontent.com/6690098/173797090-666527ba-36ab-4eb2-8a41-b877d6ad2a67.png)
![Screenshot 2022-06-15 at 10 50 19](https://user-images.githubusercontent.com/6690098/173797097-36bdf0a7-29c0-44d2-a858-e0cdfba21777.png)

**Notes**
- Tooltip sometimes is really narrow (depends on the number of reactions, and the position of the reaction): fixing that is part of the context menu fix: https://github.com/GetStream/stream-chat-angular/issues/302 
- This is a simplistic UI - this is the enhancement issue to create the intended design: https://github.com/GetStream/stream-chat-css/issues/122
- The original design contains the reaction selector inside the message actions box - implementing that design is part of this issue: https://github.com/GetStream/stream-chat-css/issues/115 
- Currently the reaction selector isn't positioned relative to the 🙂 button, but relative to the message component - this is due to the current markup, couldn't really find a better solution - the bright side is that it doesn't have the overflow problem other UI elements have