### PR TITLE
feat: Modal component theme-v2 #278

### DIFF
--- a/projects/sample-app/src/app/emoji-picker/emoji-picker.component.ts
+++ b/projects/sample-app/src/app/emoji-picker/emoji-picker.component.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  ElementRef,
-  Input,
-  OnDestroy,
-  OnInit,
-  ViewChild,
-} from '@angular/core';
+import { Component, ElementRef, Input, ViewChild } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { ThemeService } from 'stream-chat-angular';
 
@@ -14,7 +7,7 @@ import { ThemeService } from 'stream-chat-angular';
   templateUrl: './emoji-picker.component.html',
   styleUrls: ['./emoji-picker.component.scss'],
 })
-export class EmojiPickerComponent implements OnInit, OnDestroy {
+export class EmojiPickerComponent {
   isOpened = false;
   theme$: Observable<string>;
   @Input() emojiInput$: Subject<string> | undefined;
@@ -22,13 +15,6 @@ export class EmojiPickerComponent implements OnInit, OnDestroy {
 
   constructor(themeService: ThemeService) {
     this.theme$ = themeService.theme$;
-  }
-
-  ngOnInit(): void {
-    document.addEventListener('click', () => {});
-  }
-  ngOnDestroy(): void {
-    throw new Error('Method not implemented.');
   }
 
   emojiSelected(event: any) {

--- a/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.html
+++ b/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.html
@@ -231,9 +231,12 @@
 </ng-template>
 
 <ng-template #modalContent>
-  <div class="stream-chat-angular__image-modal">
+  <div class="stream-chat-angular__image-modal str-chat__image-carousel">
     <button
-      class="stream-chat-angular__image-modal-stepper"
+      class="
+        stream-chat-angular__image-modal-stepper
+        str-chat__image-carousel-stepper
+      "
       [ngStyle]="{
         visibility: isImageModalPrevButtonVisible ? 'visible' : 'hidden'
       }"
@@ -245,7 +248,10 @@
       <stream-icon-placeholder icon="arrow-left"></stream-icon-placeholder>
     </button>
     <img
-      class="stream-chat-angular__image-modal-image"
+      class="
+        stream-chat-angular__image-modal-image
+        str-chat__image-carousel-image
+      "
       data-testid="modal-image"
       [src]="
         imagesToView[imagesToViewCurrentIndex].img_url ||
@@ -255,7 +261,10 @@
       [alt]="imagesToView[imagesToViewCurrentIndex].fallback"
     />
     <button
-      class="stream-chat-angular__image-modal-stepper"
+      class="
+        stream-chat-angular__image-modal-stepper
+        str-chat__image-carousel-stepper
+      "
       type="button"
       [ngStyle]="{
         visibility: isImageModalNextButtonVisible ? 'visible' : 'hidden'

--- a/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.html
+++ b/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.html
@@ -87,12 +87,18 @@
       "
     >
       <div class="str-chat__edit-message-form-options">
-        <button translate data-testid="cancel-button" (click)="modalClosed()">
+        <button
+          class="str-chat__edit-message-cancel"
+          translate
+          data-testid="cancel-button"
+          (click)="modalClosed()"
+        >
           streamChat.Cancel
         </button>
         <button
           type="submit"
           translate
+          class="str-chat__edit-message-send"
           data-testid="send-button"
           (click)="sendClicked()"
           (keyup.enter)="sendClicked()"

--- a/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.spec.ts
@@ -142,17 +142,15 @@ describe('AutocompleteTextareaComponent', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it('shouldn increase and decrease textarea height with text input', () => {
-    const spy = jasmine.createSpy();
-    component.send.subscribe(spy);
+  it('should increase and decrease textarea height with text input', () => {
     const textarea = queryTextarea();
     textarea!.value = 'This is my message';
     fixture.detectChanges();
     const initialHeight = textarea!.offsetHeight;
+    textarea!.value = 'This is my message \n';
     textarea?.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true })
+      new KeyboardEvent('input', { key: 'Enter', shiftKey: true })
     );
-    textarea?.dispatchEvent(new KeyboardEvent('input', { key: 'R' }));
     fixture.detectChanges();
     const newHeight = textarea!.offsetHeight;
 
@@ -435,5 +433,16 @@ describe('AutocompleteTextareaComponent', () => {
 
     expect(textarea.value).toEqual('Emoji here: 🥑!');
     expect(spy).toHaveBeenCalledWith('Emoji here: 🥑!');
+  });
+
+  it('should set initial height of the textarea based on value received', () => {
+    const textarea = queryTextarea();
+    textarea!.value = 'This is my \n multiline message';
+    component.ngAfterViewInit();
+    fixture.detectChanges();
+
+    const height = parseInt(textarea?.style.height?.replace('px', '') || '');
+
+    expect(height).toBeGreaterThan(0);
   });
 });

--- a/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts
+++ b/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts
@@ -1,4 +1,5 @@
 import {
+  AfterViewInit,
   Component,
   ElementRef,
   EventEmitter,
@@ -37,7 +38,7 @@ import { ThemeService } from '../../theme.service';
   styles: [],
 })
 export class AutocompleteTextareaComponent
-  implements TextareaInterface, OnChanges
+  implements TextareaInterface, OnChanges, AfterViewInit
 {
   @HostBinding() class =
     'str-chat__textarea str-chat__message-textarea-angular-host';
@@ -187,6 +188,12 @@ export class AutocompleteTextareaComponent
     }
   }
 
+  ngAfterViewInit(): void {
+    if (this.messageInput.nativeElement.scrollHeight > 0) {
+      this.adjustTextareaHeight();
+    }
+  }
+
   filter(searchString: string, items: { autocompleteLabel: string }[]) {
     return items.filter((item) =>
       this.transliterate(item.autocompleteLabel.toLowerCase()).includes(
@@ -220,10 +227,7 @@ export class AutocompleteTextareaComponent
 
   inputChanged() {
     this.valueChange.emit(this.messageInput.nativeElement.value);
-    if (this.themeService.themeVersion === '2') {
-      this.messageInput.nativeElement.style.height = '';
-      this.messageInput.nativeElement.style.height = `${this.messageInput.nativeElement.scrollHeight}px`;
-    }
+    this.adjustTextareaHeight();
   }
 
   inputLeft() {
@@ -234,6 +238,13 @@ export class AutocompleteTextareaComponent
     event.preventDefault();
     this.updateMentionedUsersFromText();
     this.send.next();
+  }
+
+  private adjustTextareaHeight() {
+    if (this.themeService.themeVersion === '2') {
+      this.messageInput.nativeElement.style.height = '';
+      this.messageInput.nativeElement.style.height = `${this.messageInput.nativeElement.scrollHeight}px`;
+    }
   }
 
   private transliterate(s: string) {

--- a/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.spec.ts
@@ -123,17 +123,15 @@ describe('TextareaComponent', () => {
     expect(spy).toHaveBeenCalledWith('Emoji here: 🥑!');
   });
 
-  it('shouldn increase and decrease textarea height with text input', () => {
-    const spy = jasmine.createSpy();
-    component.send.subscribe(spy);
+  it('should increase and decrease textarea height with text input', () => {
     const textarea = queryTextarea();
     textarea!.value = 'This is my message';
     fixture.detectChanges();
     const initialHeight = textarea!.offsetHeight;
+    textarea!.value = 'This is my message \n';
     textarea?.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'Enter', shiftKey: true })
+      new KeyboardEvent('input', { key: 'Enter', shiftKey: true })
     );
-    textarea?.dispatchEvent(new KeyboardEvent('input', { key: 'R' }));
     fixture.detectChanges();
     const newHeight = textarea!.offsetHeight;
 
@@ -144,5 +142,16 @@ describe('TextareaComponent', () => {
     fixture.detectChanges();
 
     expect(textarea!.offsetHeight).toBeLessThan(newHeight);
+  });
+
+  it('should set initial height of the textarea based on value received', () => {
+    const textarea = queryTextarea();
+    textarea!.value = 'This is my \n multiline message';
+    component.ngAfterViewInit();
+    fixture.detectChanges();
+
+    const height = parseInt(textarea?.style.height?.replace('px', '') || '');
+
+    expect(height).toBeGreaterThan(0);
   });
 });

--- a/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts
+++ b/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts
@@ -1,4 +1,5 @@
 import {
+  AfterViewInit,
   Component,
   ElementRef,
   EventEmitter,
@@ -24,7 +25,7 @@ import { TextareaInterface } from '../textarea.interface';
   styles: [],
 })
 export class TextareaComponent
-  implements TextareaInterface, OnChanges, OnDestroy
+  implements TextareaInterface, OnChanges, OnDestroy, AfterViewInit
 {
   @HostBinding() class =
     'str-chat__textarea str-chat__message-textarea-angular-host';
@@ -71,20 +72,30 @@ export class TextareaComponent
     }
   }
 
+  ngAfterViewInit(): void {
+    if (this.messageInput.nativeElement.scrollHeight > 0) {
+      this.adjustTextareaHeight();
+    }
+  }
+
   ngOnDestroy(): void {
     this.subscriptions.forEach((s) => s.unsubscribe());
   }
 
   inputChanged() {
     this.valueChange.emit(this.messageInput.nativeElement.value);
-    if (this.themeService.themeVersion === '2') {
-      this.messageInput.nativeElement.style.height = '';
-      this.messageInput.nativeElement.style.height = `${this.messageInput.nativeElement.scrollHeight}px`;
-    }
+    this.adjustTextareaHeight();
   }
 
   sent(event: Event) {
     event.preventDefault();
     this.send.next();
+  }
+
+  private adjustTextareaHeight() {
+    if (this.themeService.themeVersion === '2') {
+      this.messageInput.nativeElement.style.height = '';
+      this.messageInput.nativeElement.style.height = `${this.messageInput.nativeElement.scrollHeight}px`;
+    }
   }
 }

--- a/projects/stream-chat-angular/src/lib/message/message.component.html
+++ b/projects/stream-chat-angular/src/lib/message/message.component.html
@@ -36,6 +36,7 @@
         <div
           class="str-chat__message-simple__actions str-chat__message-options"
           data-testid="message-options"
+          [class.str-chat__message-edit-in-progress]="isEditing"
           *ngIf="areOptionsVisible"
         >
           <div
@@ -80,6 +81,7 @@
               *ngIf="visibleMessageActionsCount > 0"
               data-testid="action-icon"
               icon="action-icon"
+              class="str-chat__message-action-icon"
               (keyup.enter)="isActionBoxOpen = !isActionBoxOpen"
               (click)="isActionBoxOpen = !isActionBoxOpen"
             ></stream-icon-placeholder>
@@ -100,6 +102,7 @@
             (keyup.enter)="setAsActiveParentMessage()"
           >
             <stream-icon-placeholder
+              class="str-chat__message-action-icon"
               icon="reply-in-thread"
             ></stream-icon-placeholder>
           </div>
@@ -115,6 +118,7 @@
             (keyup.enter)="isReactionSelectorOpen = !isReactionSelectorOpen"
           >
             <stream-icon-placeholder
+              class="str-chat__message-action-icon"
               icon="reaction-icon"
             ></stream-icon-placeholder>
           </div>

--- a/projects/stream-chat-angular/src/lib/modal/modal.component.html
+++ b/projects/stream-chat-angular/src/lib/modal/modal.component.html
@@ -7,9 +7,7 @@
     class="str-chat__modal__close-button"
     (click)="close()"
     (keyup.enter)="close()"
-    translate
   >
-    streamChat.Close
     <stream-icon-placeholder icon="close"></stream-icon-placeholder>
   </div>
   <div class="str-chat__modal__inner" #modalInner>


### PR DESCRIPTION
## Figma

<img width="741" alt="Screenshot 2022-06-17 at 11 37 51" src="https://user-images.githubusercontent.com/6690098/174272263-37f6f8c0-00aa-43ca-b323-df239012c751.png">
<img width="740" alt="Screenshot 2022-06-17 at 11 38 04" src="https://user-images.githubusercontent.com/6690098/174272276-38dcf4a6-8534-4f56-8dcb-d18abbbe2c39.png">
<img width="491" alt="Screenshot 2022-06-17 at 13 02 52" src="https://user-images.githubusercontent.com/6690098/174286257-8cf9fe83-cce3-4ea1-896c-b89176096049.png">

## Implementation

The modal component is displayed in the following use-cases:

### Image carousel
<img width="1506" alt="Screenshot 2022-06-17 at 12 57 56" src="https://user-images.githubusercontent.com/6690098/174285689-77b87ba0-0dd9-49e0-b6d7-a38f3cdd8393.png">
<img width="1500" alt="Screenshot 2022-06-17 at 12 59 06" src="https://user-images.githubusercontent.com/6690098/174285705-f03c08e9-80dc-414e-9e3d-80bc246e2735.png">

**Enhancement issue for full Figma design**: https://github.com/GetStream/stream-chat-css/issues/126

### Editing a message

<img width="1508" alt="Screenshot 2022-06-17 at 13 01 41" src="https://user-images.githubusercontent.com/6690098/174286143-17ab1224-b460-47d6-b7d3-956a2f4dfbc6.png">
<img width="1504" alt="Screenshot 2022-06-17 at 13 02 01" src="https://user-images.githubusercontent.com/6690098/174286147-a54e6ad9-504f-4f28-8744-ffd4ba7ebbef.png">

Modal height grows with input size until max height is reached.

Known issue: The only way I could do the dynamic height of the modal was with `flax-basis`, but Safari doesn't support [flex-basis: min-content](https://caniuse.com/mdn-css_properties_flex-basis_min-content) so the modal is always max height there (see: https://github.com/GetStream/stream-chat-css/pull/127/files#diff-81e3a83444bc00479e86d1e5b47952fdb3fc042e95e3c4ec9adb4f396f0ca646R41)

<img width="1571" alt="Screenshot 2022-06-17 at 13 04 05" src="https://user-images.githubusercontent.com/6690098/174286412-5651f43d-234f-45d4-bdc9-48f928fe13e1.png">

It'd be also nice to have dynamic width as well, but I wasn't able to do it (it was either max width or the content overflowed) - **UPDATE** found the solution

 I'm sure there is a solution for the problems above, if someone has an idea, I'm happy to try it.

<img width="370" alt="Screenshot 2022-06-17 at 13 09 01" src="https://user-images.githubusercontent.com/6690098/174287161-cbc35c64-2947-415e-a1f5-d443c7a8b981.png">

**Enhancement issue** Different edit message layout https://github.com/GetStream/stream-chat-css/issues/125

closes #278 