### PR TITLE
Notifications theme v2

### DIFF
--- a/docusaurus/docs/Angular/code-examples/responsive-layout.mdx
+++ b/docusaurus/docs/Angular/code-examples/responsive-layout.mdx
@@ -19,7 +19,6 @@ Let's create a simple chat application UI:
   <stream-channel class="channel">
     <stream-channel-header> </stream-channel-header>
     <stream-message-list></stream-message-list>
-    <stream-notification-list></stream-notification-list>
     <stream-message-input></stream-message-input>
     <stream-thread class="thread" name="thread">
       <stream-message-list
@@ -32,6 +31,7 @@ Let's create a simple chat application UI:
       ></stream-message-input>
     </stream-thread>
   </stream-channel>
+  <stream-notification-list></stream-notification-list>
 </div>
 ```
 

--- a/docusaurus/docs/Angular/components/ChannelComponent.mdx
+++ b/docusaurus/docs/Angular/components/ChannelComponent.mdx
@@ -9,7 +9,6 @@ The `Channel` component is a container component that displays the [`ChannelHead
     <!-- Main messages in the channel -->
     <stream-channel-header></stream-channel-header>
     <stream-message-list></stream-message-list>
-    <stream-notification-list></stream-notification-list>
     <stream-message-input></stream-message-input>
     <!-- Main messages in the channel -->
     <!-- Thread messages in the channel -->
@@ -25,6 +24,7 @@ The `Channel` component is a container component that displays the [`ChannelHead
     </stream-thread>
     <!-- Thread messages in the channel -->
   </stream-channel>
+  <stream-notification-list></stream-notification-list>
 </div>
 ```
 

--- a/docusaurus/docs/Angular/components/NotificationListComponent.mdx
+++ b/docusaurus/docs/Angular/components/NotificationListComponent.mdx
@@ -10,9 +10,9 @@ You can use the `NotificationList` component to display the active notifications
   <stream-channel>
     <stream-channel-header></stream-channel-header>
     <stream-message-list></stream-message-list>
-    <stream-notification-list></stream-notification-list>
     <stream-message-input></stream-message-input>
   </stream-channel>
+  <stream-notification-list></stream-notification-list>
 </div>
 ```
 

--- a/docusaurus/docs/Angular/concepts/customization.mdx
+++ b/docusaurus/docs/Angular/concepts/customization.mdx
@@ -17,7 +17,6 @@ This is how our initial chat UI looks like:
   <!-- Main messages in the channel -->
   <stream-channel-header></stream-channel-header>
   <stream-message-list></stream-message-list>
-  <stream-notification-list></stream-notification-list>
   <stream-message-input></stream-message-input>
   <!-- Main messages in the channel -->
   <!-- Thread messages in the channel -->
@@ -33,6 +32,7 @@ This is how our initial chat UI looks like:
   </stream-thread>
   <!-- Thread messages in the channel -->
 </stream-channel>
+<stream-notification-list></stream-notification-list>
 ```
 
 This template lives in your application so you can freely replace any component with your own custom component, for example if you want to use your own channel header you can just replace `stream-channel-header` with your own component.

--- a/projects/sample-app/src/app/app.component.html
+++ b/projects/sample-app/src/app/app.component.html
@@ -15,9 +15,7 @@
       </button>
     </stream-channel-header>
     <stream-message-list></stream-message-list>
-    <stream-notification-list
-      *ngIf="themeVersion === '1'"
-    ></stream-notification-list>
+    <stream-notification-list></stream-notification-list>
     <stream-message-input></stream-message-input>
     <stream-thread class="thread" name="thread">
       <stream-message-list
@@ -30,9 +28,6 @@
       ></stream-message-input>
     </stream-thread>
   </stream-channel>
-  <stream-notification-list
-    *ngIf="themeVersion === '2'"
-  ></stream-notification-list>
 </div>
 
 <!-- To use custom message, add this input to stream-message-list: [messageTemplate]="customMessagetemplate"-->

--- a/projects/sample-app/src/app/app.component.html
+++ b/projects/sample-app/src/app/app.component.html
@@ -15,7 +15,9 @@
       </button>
     </stream-channel-header>
     <stream-message-list></stream-message-list>
-    <stream-notification-list></stream-notification-list>
+    <stream-notification-list
+      *ngIf="themeVersion === '1'"
+    ></stream-notification-list>
     <stream-message-input></stream-message-input>
     <stream-thread class="thread" name="thread">
       <stream-message-list
@@ -28,6 +30,9 @@
       ></stream-message-input>
     </stream-thread>
   </stream-channel>
+  <stream-notification-list
+    *ngIf="themeVersion === '2'"
+  ></stream-notification-list>
 </div>
 
 <!-- To use custom message, add this input to stream-message-list: [messageTemplate]="customMessagetemplate"-->

--- a/projects/sample-app/src/app/app.component.ts
+++ b/projects/sample-app/src/app/app.component.ts
@@ -11,6 +11,7 @@ import {
   StreamI18nService,
   EmojiPickerContext,
   CustomTemplatesService,
+  ThemeService,
 } from 'stream-chat-angular';
 import { environment } from '../environments/environment';
 
@@ -24,11 +25,14 @@ export class AppComponent implements AfterViewInit {
   isThreadOpen = false;
   @ViewChild('emojiPickerTemplate')
   emojiPickerTemplate!: TemplateRef<EmojiPickerContext>;
+  themeVersion: '1' | '2';
+
   constructor(
     private chatService: ChatClientService,
     private channelService: ChannelService,
     private streamI18nService: StreamI18nService,
-    private customTemplateService: CustomTemplatesService
+    private customTemplateService: CustomTemplatesService,
+    themeService: ThemeService
   ) {
     void this.chatService.init(
       environment.apiKey,
@@ -43,7 +47,9 @@ export class AppComponent implements AfterViewInit {
     this.channelService.activeParentMessage$
       .pipe(map((m) => !!m))
       .subscribe((isThreadOpen) => (this.isThreadOpen = isThreadOpen));
+    this.themeVersion = themeService.themeVersion;
   }
+
   ngAfterViewInit(): void {
     this.customTemplateService.emojiPickerTemplate$.next(
       this.emojiPickerTemplate

--- a/projects/stream-chat-angular/src/assets/i18n/en.ts
+++ b/projects/stream-chat-angular/src/assets/i18n/en.ts
@@ -17,7 +17,7 @@ export const en = {
     'Empty message...': 'Empty message...',
     'Error adding flag': 'Error adding flag',
     'Error connecting to chat, refresh the page to try again.':
-      'Error connecting to chat, refresh the page to try again.',
+      'Error connecting to chat, refresh the page to try again',
     'Error deleting message': 'Error deleting message',
     'Error muting a user ...': 'Error muting a user ...',
     'Error pinning message': 'Error pinning message',
@@ -98,5 +98,6 @@ export const en = {
     'No chats here yet…': 'No chats here yet…',
     'user is typing': '{{ user }} is typing',
     'users are typing': '{{ users }} are typing',
+    'Error loading channels': 'Error loading channels',
   },
 };

--- a/projects/stream-chat-angular/src/lib/channel/channel.component.html
+++ b/projects/stream-chat-angular/src/lib/channel/channel.component.html
@@ -32,6 +32,9 @@
       <p class="str-chat__empty-channel-text">
         {{ "streamChat.No chats here yet…" | translate }}
       </p>
+      <div class="str-chat__empty-channel-notifications">
+        <stream-notification-list></stream-notification-list>
+      </div>
     </div>
     <div
       *ngIf="

--- a/projects/stream-chat-angular/src/lib/chat-client.service.ts
+++ b/projects/stream-chat-angular/src/lib/chat-client.service.ts
@@ -86,7 +86,15 @@ export class ChatClientService<
     this.chatClient.devToken;
     await this.ngZone.runOutsideAngular(async () => {
       const user = typeof userOrId === 'string' ? { id: userOrId } : userOrId;
-      await this.chatClient.connectUser(user, userTokenOrProvider);
+      try {
+        await this.chatClient.connectUser(user, userTokenOrProvider);
+      } catch (error) {
+        this.notificationService.addPermanentNotification(
+          'streamChat.Error connecting to chat, refresh the page to try again.',
+          'error'
+        );
+        throw error;
+      }
       this.chatClient.setUserAgent(
         `stream-chat-angular-${version}-${this.chatClient.getUserAgent()}`
       );

--- a/projects/stream-chat-angular/src/lib/notification-list/notification-list.component.html
+++ b/projects/stream-chat-angular/src/lib/notification-list/notification-list.component.html
@@ -1,4 +1,10 @@
-<div class="str-chat__list-notifications">
+<div
+  class="str-chat str-chat__theme-{{
+    theme$ | async
+  }} str-chat__list-notifications"
+  [class.str-chat]="themeVersion === '2'"
+  data-testid="notification-list"
+>
   <ng-container
     *ngFor="let notification of notifications$ | async; trackBy: trackById"
   >

--- a/projects/stream-chat-angular/src/lib/notification-list/notification-list.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/notification-list/notification-list.component.spec.ts
@@ -3,6 +3,7 @@ import { By } from '@angular/platform-browser';
 import { TranslateModule } from '@ngx-translate/core';
 import { NotificationService } from '../notification.service';
 import { NotificationComponent } from '../notification/notification.component';
+import { ThemeService } from '../theme.service';
 
 import { NotificationListComponent } from './notification-list.component';
 
@@ -10,9 +11,11 @@ describe('NotificationListComponent', () => {
   let fixture: ComponentFixture<NotificationListComponent>;
   let queryNotificationComponents: () => NotificationComponent[];
   let queryNotificationContents: () => HTMLElement[];
+  let queryContainer: () => HTMLElement;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      providers: [ThemeService],
       imports: [TranslateModule.forRoot()],
       declarations: [NotificationListComponent, NotificationComponent],
     }).compileComponents();
@@ -31,6 +34,10 @@ describe('NotificationListComponent', () => {
           '[data-testclass="notification-content"]'
         )
       );
+    queryContainer = () =>
+      (fixture.nativeElement as HTMLElement).querySelector(
+        '[data-testid="notification-list"]'
+      ) as HTMLElement;
   });
 
   it('should display notifications', () => {
@@ -46,5 +53,21 @@ describe('NotificationListComponent', () => {
     expect(notificationComponents[1].type).toBe('error');
     expect(notificationContents[0].innerHTML).toContain('Message flaged');
     expect(notificationContents[1].innerHTML).toContain('Connection failure');
+  });
+
+  it('should apply dark/light theme', () => {
+    const service = TestBed.inject(ThemeService);
+    const lightClass = 'str-chat__theme-light';
+    const darkClass = 'str-chat__theme-dark';
+    const container = queryContainer();
+    fixture.detectChanges();
+
+    expect(container?.classList.contains(lightClass)).toBeTrue();
+    expect(container?.classList.contains(darkClass)).toBeFalse();
+
+    service.theme$.next('dark');
+    fixture.detectChanges();
+
+    expect(container?.classList.contains(darkClass)).toBeTrue();
   });
 });

--- a/projects/stream-chat-angular/src/lib/notification-list/notification-list.component.ts
+++ b/projects/stream-chat-angular/src/lib/notification-list/notification-list.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
 import { CustomTemplatesService } from '../custom-templates.service';
 import { NotificationService } from '../notification.service';
+import { ThemeService } from '../theme.service';
 import { NotificationPayload } from '../types';
 
 /**
@@ -14,12 +15,17 @@ import { NotificationPayload } from '../types';
 })
 export class NotificationListComponent {
   notifications$: Observable<NotificationPayload[]>;
+  themeVersion: '1' | '2';
+  theme$: Observable<string>;
 
   constructor(
     public readonly customTemplatesService: CustomTemplatesService,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private themeService: ThemeService
   ) {
     this.notifications$ = this.notificationService.notifications$;
+    this.theme$ = this.themeService.theme$;
+    this.themeVersion = this.themeService.themeVersion;
   }
 
   trackById(_: number, item: NotificationPayload) {

--- a/projects/stream-chat-angular/src/lib/notification/notification.component.html
+++ b/projects/stream-chat-angular/src/lib/notification/notification.component.html
@@ -1,5 +1,7 @@
 <div
-  class="str-chat__custom-notification notification-{{ type }}"
+  class="str-chat__custom-notification notification-{{
+    type
+  }} str-chat__notification"
   data-testid="custom-notification"
 >
   <ng-container *ngIf="content; else elseContent">


### PR DESCRIPTION
closes #277 

## Figma
<img width="870" alt="Screenshot 2022-06-20 at 14 09 54" src="https://user-images.githubusercontent.com/6690098/174627736-21263203-4792-438c-90f0-a33a30e3c5ec.png">
<img width="289" alt="Screenshot 2022-06-20 at 14 11 59" src="https://user-images.githubusercontent.com/6690098/174627761-027468c3-b1cd-4e63-8beb-63f05b18af3b.png">
<img width="239" alt="Screenshot 2022-06-20 at 16 49 20" src="https://user-images.githubusercontent.com/6690098/174628160-16d17f0f-a50a-4daa-99ce-d22fc4aa0ce7.png">


## Implementation

For the notification positioning, we should take into account the edit message modal, notifications should also be visible when this modal is open - I ended up positioning the notifications at the middle-bottom of the screen so they look ok with the modal open as well - will also discuss this with Fra after he is back in the office


<img width="1271" alt="Screenshot 2022-06-20 at 14 04 21" src="https://user-images.githubusercontent.com/6690098/174628523-0be9ebcd-3cd3-4917-8545-5c34cc8b3ab5.png">
<img width="1268" alt="Screenshot 2022-06-20 at 14 04 12" src="https://user-images.githubusercontent.com/6690098/174628532-6bb54316-cb19-447d-a3df-7a48a11348a9.png">
<img width="1261" alt="Screenshot 2022-06-20 at 14 20 34" src="https://user-images.githubusercontent.com/6690098/174628588-a827e2b0-b969-4211-b948-ffb452740f83.png">
<img width="379" alt="Screenshot 2022-06-20 at 14 18 14" src="https://user-images.githubusercontent.com/6690098/174628962-7742e95c-010a-45d2-83d4-375c34250030.png">

