### PR TITLE
fix: Message update event handler doesn't respect order change and deletion

### DIFF
--- a/projects/stream-chat-angular/src/lib/channel.service.spec.ts
+++ b/projects/stream-chat-angular/src/lib/channel.service.spec.ts
@@ -436,9 +436,8 @@ describe('ChannelService', () => {
     spy.calls.reset();
     let activeChannel!: Channel<DefaultStreamChatGenerics>;
     service.activeChannel$.subscribe((c) => (activeChannel = c!));
-    const message = {
-      ...activeChannel.state.messages[activeChannel.state.messages.length - 1],
-    };
+    const message =
+      activeChannel.state.messages[activeChannel.state.messages.length - 1];
     message.deleted_at = new Date().toISOString();
     (activeChannel as MockChannel).handleEvent('message.deleted', { message });
 


### PR DESCRIPTION
After `message.updated` or `message.deleted` WS events the order of messages can change (the timestamp of a message can change), and messages can be deleted from the list (if we used hard delete) -> the SDK didn't account for those use-cases before, this is a fix for that