### PR TITLE
feat: Add guest user connection option

### DIFF
--- a/projects/stream-chat-angular/src/lib/chat-client.service.spec.ts
+++ b/projects/stream-chat-angular/src/lib/chat-client.service.spec.ts
@@ -29,7 +29,10 @@ describe('ChatClientService', () => {
     await service.init(apiKey, userId, userToken);
   });
 
-  it('should connect user', () => {
+  it('should connect user', async () => {
+    mockChatClient.connectUser.calls.reset();
+    await service.init(apiKey, userId, userToken);
+
     expect(StreamChat.getInstance).toHaveBeenCalledWith(apiKey);
     const spy = jasmine.createSpy();
     service.appSettings$.subscribe(spy);
@@ -38,6 +41,26 @@ describe('ChatClientService', () => {
 
     expect(spy).toHaveBeenCalledWith(undefined);
     expect(userSpy).toHaveBeenCalledWith(mockCurrentUser());
+    expect(mockChatClient.connectUser).toHaveBeenCalledWith(
+      { id: userId },
+      userToken
+    );
+  });
+
+  it('should connect user - guest user', async () => {
+    mockChatClient.connectUser.calls.reset();
+    await service.init(apiKey, userId, 'guest');
+
+    expect(StreamChat.getInstance).toHaveBeenCalledWith(apiKey);
+    const spy = jasmine.createSpy();
+    service.appSettings$.subscribe(spy);
+    const userSpy = jasmine.createSpy();
+    service.user$.subscribe(userSpy);
+
+    expect(spy).toHaveBeenCalledWith(undefined);
+    expect(userSpy).toHaveBeenCalledWith(mockCurrentUser());
+    expect(mockChatClient.connectUser).not.toHaveBeenCalled();
+    expect(mockChatClient.setGuestUser).toHaveBeenCalledWith({ id: userId });
   });
 
   it('should disconnect user', async () => {

--- a/projects/stream-chat-angular/src/lib/chat-client.service.ts
+++ b/projects/stream-chat-angular/src/lib/chat-client.service.ts
@@ -83,19 +83,22 @@ export class ChatClientService<
    * Creates a [`StreamChat`](https://github.com/GetStream/stream-chat-js/blob/668b3e5521339f4e14fc657834531b4c8bf8176b/src/client.ts#L124) instance using the provided `apiKey`, and connects a user with the given meta data and token. More info about [connecting users](https://getstream.io/chat/docs/javascript/init_and_users/?language=javascript) can be found in the platform documentation.
    * @param apiKey
    * @param userOrId
-   * @param userTokenOrProvider
+   * @param userTokenOrProvider You can provide a token, or the keyword 'guest' to connect as [guest user](https://getstream.io/chat/docs/javascript/authless_users/?language=javascript#guest-users)
    */
   async init(
     apiKey: string,
     userOrId: string | OwnUserResponse<T> | UserResponse<T>,
-    userTokenOrProvider: TokenOrProvider
+    userTokenOrProvider: TokenOrProvider | 'guest'
   ): ConnectAPIResponse<T> {
     this.chatClient = StreamChat.getInstance<T>(apiKey);
     this.chatClient.devToken;
     let result;
     await this.ngZone.runOutsideAngular(async () => {
       const user = typeof userOrId === 'string' ? { id: userOrId } : userOrId;
-      result = await this.chatClient.connectUser(user, userTokenOrProvider);
+      result =
+        userTokenOrProvider === 'guest'
+          ? await this.chatClient.setGuestUser(user)
+          : await this.chatClient.connectUser(user, userTokenOrProvider);
       this.userSubject.next(this.chatClient.user);
       this.chatClient.setUserAgent(
         `stream-chat-angular-${version}-${this.chatClient.getUserAgent()}`

--- a/projects/stream-chat-angular/src/lib/mocks/index.ts
+++ b/projects/stream-chat-angular/src/lib/mocks/index.ts
@@ -275,6 +275,7 @@ export type MockStreamChatClient = {
   appSettings$: Subject<AppSettings>;
   user: UserResponse;
   connectUser: jasmine.Spy;
+  setGuestUser: jasmine.Spy;
   on: (name: EventTypes, handler: () => {}) => { unsubscribe: () => void };
   handleEvent: (name: EventTypes, event: Event) => void;
   flagMessage: jasmine.Spy;
@@ -290,6 +291,7 @@ export const mockStreamChatClient = (): MockStreamChatClient => {
   const eventHandlers: { [key: string]: Function } = {};
   /* eslint-disable jasmine/no-unsafe-spy */
   const connectUser = jasmine.createSpy();
+  const setGuestUser = jasmine.createSpy();
   const flagMessage = jasmine.createSpy();
   const setUserAgent = jasmine.createSpy();
   const queryUsers = jasmine.createSpy();
@@ -347,6 +349,7 @@ export const mockStreamChatClient = (): MockStreamChatClient => {
     getAppSettings,
     appSettings$,
     queryChannels,
+    setGuestUser,
   };
 };
 


### PR DESCRIPTION
The plan is to use [guest user authentication](https://getstream.io/chat/docs/javascript/authless_users/?language=javascript#guest-users) for the theming blog post playground