### PR TITLE
fix: Duplicated channels after two notification events and not up to …

### DIFF
--- a/projects/stream-chat-angular/src/lib/channel.service.spec.ts
+++ b/projects/stream-chat-angular/src/lib/channel.service.spec.ts
@@ -766,7 +766,7 @@ describe('ChannelService', () => {
     expect(channel.on).toHaveBeenCalledWith(jasmine.any(Function));
   }));
 
-  it(`shouldn't add channels duplicated if two notification event is received for the same channel`, fakeAsync(async () => {
+  it(`shouldn't add channels twice if two notification events were received for the same channel`, fakeAsync(async () => {
     await init();
     const channel = generateMockChannels()[0];
     channel.cid = 'channel';

--- a/projects/stream-chat-angular/src/lib/channel.service.ts
+++ b/projects/stream-chat-angular/src/lib/channel.service.ts
@@ -273,11 +273,8 @@ export class ChannelService<
     const deletedChannels = currentChannels.filter(
       (c) => !channels?.find((channel) => channel.cid === c.cid)
     );
-    this.addChannelsFromNotification(newChannels as ChannelResponse<T>[]);
+    void this.addChannelsFromNotification(newChannels as ChannelResponse<T>[]);
     this.removeChannelsFromChannelList(deletedChannels.map((c) => c.cid));
-    if (!newChannels.length && !deletedChannels.length) {
-      this.channelsSubject.next(channels as Channel<T>[]);
-    }
   };
 
   private messageListSetter = (messages: StreamMessage<T>[]) => {
@@ -866,13 +863,13 @@ export class ChannelService<
 
   private handleNewMessageNotification(clientEvent: ClientEvent<T>) {
     if (clientEvent.event.channel) {
-      this.addChannelsFromNotification([clientEvent.event.channel]);
+      void this.addChannelsFromNotification([clientEvent.event.channel]);
     }
   }
 
   private handleAddedToChannelNotification(clientEvent: ClientEvent<T>) {
     if (clientEvent.event.channel) {
-      this.addChannelsFromNotification([clientEvent.event.channel]);
+      void this.addChannelsFromNotification([clientEvent.event.channel]);
     }
   }
 


### PR DESCRIPTION
…date channel state

This PR fixes two bugs reported by a customer:
- When a channel was added after a [`notification.*`](https://getstream.io/chat/docs/javascript/event_object/?language=javascript) event the SDK didn't wait for the response of the `watch` request and that meant that we didn't ensure that the latest messages were displayed inside the SDK
- When two `notification` events were received for the same channel very close in time (for example `notification.added_to_channel` and `notifiaction_message_new`, close in time means that the second `notification` event is received before the channel watch request is finished that is triggered by the first `notification` event) the channel was added twice to the channel list

+1 I discovered that that `channelListSetter` method (called if someone overrides the default channel event handlers) had an unnecessary emit, so I removed that