### PR TITLE
Scroll to quoted message

### DIFF
--- a/projects/stream-chat-angular/src/assets/i18n/en.ts
+++ b/projects/stream-chat-angular/src/assets/i18n/en.ts
@@ -95,5 +95,6 @@ export const en = {
     "You can't send thread replies in this channel":
       "You can't send thread replies in this channel",
     'Unsupported file type: {{type}}': 'Unsupported file type: {{type}}',
+    'Message not found': 'Message not found',
   },
 };

--- a/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.ts
+++ b/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.ts
@@ -107,8 +107,9 @@ export class ChannelPreviewComponent implements OnInit, OnDestroy {
       }
       if (
         !event.message ||
-        this.channel?.state.messages[this.channel?.state.messages.length - 1]
-          .id !== event.message.id
+        this.channel?.state.latestMessages[
+          this.channel?.state.latestMessages.length - 1
+        ].id !== event.message.id
       ) {
         return;
       }

--- a/projects/stream-chat-angular/src/lib/channel.service.thread.spec.ts
+++ b/projects/stream-chat-angular/src/lib/channel.service.thread.spec.ts
@@ -18,6 +18,7 @@ import {
   mockCurrentUser,
   mockMessage,
 } from './mocks';
+import { NotificationService } from './notification.service';
 import { DefaultStreamChatGenerics, StreamMessage } from './types';
 
 describe('ChannelService - threads', () => {
@@ -62,6 +63,7 @@ describe('ChannelService - threads', () => {
             connectionState$,
           },
         },
+        NotificationService,
       ],
     });
     service = TestBed.inject(ChannelService);
@@ -126,27 +128,38 @@ describe('ChannelService - threads', () => {
 
   it('should remove active parent message and reset thread messages', async () => {
     await init();
-    const messageToQuote = mockMessage();
-    messageToQuote.parent_id = 'parentId';
-    service.selectMessageToQuote(messageToQuote);
+    let parentMessage!: StreamMessage;
+    service.activeChannelMessages$.subscribe((m) => (parentMessage = m[0]));
+    const message = mockMessage();
+    message.parent_id = parentMessage.id;
+    await service.setAsActiveParentMessage(parentMessage);
+    await service.jumpToMessage(message.id, message.parent_id);
+    service.selectMessageToQuote(message);
     const messagesSpy = jasmine.createSpy();
     const activeParentMessageIdSpy = jasmine.createSpy();
     const activeParentMessageSpy = jasmine.createSpy();
     const messageToQuoteSpy = jasmine.createSpy();
+    const jumpToMessageSpy = jasmine.createSpy();
     service.activeThreadMessages$.subscribe(messagesSpy);
     service.activeParentMessageId$.subscribe(activeParentMessageIdSpy);
     service.activeParentMessage$.subscribe(activeParentMessageSpy);
     service.messageToQuote$.subscribe(messageToQuoteSpy);
+    service.jumpToMessage$.subscribe(jumpToMessageSpy);
     messagesSpy.calls.reset();
     activeParentMessageIdSpy.calls.reset();
     activeParentMessageSpy.calls.reset();
     messageToQuoteSpy.calls.reset();
+    jumpToMessageSpy.calls.reset();
     await service.setAsActiveParentMessage(undefined);
 
     expect(messagesSpy).toHaveBeenCalledWith([]);
     expect(activeParentMessageIdSpy).toHaveBeenCalledWith(undefined);
     expect(activeParentMessageSpy).toHaveBeenCalledWith(undefined);
     expect(messageToQuoteSpy).toHaveBeenCalledWith(undefined);
+    expect(jumpToMessageSpy).toHaveBeenCalledWith({
+      id: undefined,
+      parentId: undefined,
+    });
   });
 
   it(`shouldn't deselect message to quote, if not a thread reply`, async () => {
@@ -163,6 +176,22 @@ describe('ChannelService - threads', () => {
     await service.setAsActiveParentMessage(undefined);
 
     expect(messageToQuoteSpy).not.toHaveBeenCalled();
+  });
+
+  it(`shouldn't deselect jump-to-message, if not a thread reply`, async () => {
+    await init();
+    const jumpToMessageSpy = jasmine.createSpy();
+    service.jumpToMessage$.subscribe(jumpToMessageSpy);
+    const parentMessage = mockMessage();
+    parentMessage.id = 'parentMessage';
+    const messageToJump = mockMessage();
+    messageToJump.parent_id = undefined;
+    await service.setAsActiveParentMessage(parentMessage);
+    await service.jumpToMessage(messageToJump.id, messageToJump.parent_id);
+    jumpToMessageSpy.calls.reset();
+    await service.setAsActiveParentMessage(undefined);
+
+    expect(jumpToMessageSpy).not.toHaveBeenCalled();
   });
 
   it('should reset', async () => {
@@ -216,7 +245,7 @@ describe('ChannelService - threads', () => {
     threadMessages.forEach((m) => expect(m.readBy).toBeDefined());
   });
 
-  it('should load more messages', async () => {
+  it('should load more older messages', async () => {
     await init();
     const messagesSpy = jasmine.createSpy();
     service.activeThreadMessages$.subscribe(messagesSpy);
@@ -244,6 +273,29 @@ describe('ChannelService - threads', () => {
     });
 
     expect(threadMessages.length).toBe(5);
+  });
+
+  it('should do nothing if we want to load newer messages', async () => {
+    await init();
+    const messagesSpy = jasmine.createSpy();
+    service.activeThreadMessages$.subscribe(messagesSpy);
+    messagesSpy.calls.reset();
+    const parentMessage = mockMessage();
+    let channel!: Channel<DefaultStreamChatGenerics>;
+    service.activeChannel$.subscribe((c) => (channel = c!));
+    const replies = [mockMessage(), mockMessage(), mockMessage()];
+    spyOn(channel, 'getReplies').and.resolveTo({
+      messages: replies,
+    } as any as GetRepliesAPIResponse<DefaultStreamChatGenerics>);
+    replies[0].id = 'firstreply';
+    await service.setAsActiveParentMessage(parentMessage);
+    (channel.getReplies as jasmine.Spy).calls.reset();
+    channel.state.threads = {
+      [parentMessage.id]: [mockMessage(), mockMessage(), ...replies],
+    };
+    await service.loadMoreThreadReplies('newer');
+
+    expect(channel.getReplies).not.toHaveBeenCalled();
   });
 
   it('should watch for new message events', async () => {
@@ -707,5 +759,41 @@ describe('ChannelService - threads', () => {
 
     expect(usersTypingInThreadSpy).not.toHaveBeenCalled();
     expect(usersTypingInChannelSpy).not.toHaveBeenCalled();
+  });
+
+  it('should load thread message into state', async () => {
+    await init();
+    const jumpToMessageIdSpy = jasmine.createSpy();
+    service.jumpToMessage$.subscribe(jumpToMessageIdSpy);
+    jumpToMessageIdSpy.calls.reset();
+    const messagesSpy = jasmine.createSpy();
+    service.activeChannelMessages$.subscribe(messagesSpy);
+    messagesSpy.calls.reset();
+    const activeParentMessageSpy = jasmine.createSpy();
+    service.activeParentMessageId$.subscribe(activeParentMessageSpy);
+    activeParentMessageSpy.calls.reset();
+    const threadMessagesSpy = jasmine.createSpy();
+    service.activeThreadMessages$.subscribe(threadMessagesSpy);
+    threadMessagesSpy.calls.reset();
+    const messageId = '1232121123';
+    const parentMessageId = '2222';
+    await service.jumpToMessage(messageId, parentMessageId);
+
+    expect(jumpToMessageIdSpy).toHaveBeenCalledWith({
+      id: messageId,
+      parentId: parentMessageId,
+    });
+
+    expect(messagesSpy).toHaveBeenCalledWith(
+      jasmine.arrayContaining([
+        jasmine.objectContaining({ id: parentMessageId }),
+      ])
+    );
+
+    expect(activeParentMessageSpy).toHaveBeenCalledWith(parentMessageId);
+
+    expect(threadMessagesSpy).toHaveBeenCalledWith(
+      jasmine.arrayContaining([jasmine.objectContaining({ id: messageId })])
+    );
   });
 });

--- a/projects/stream-chat-angular/src/lib/channel.service.ts
+++ b/projects/stream-chat-angular/src/lib/channel.service.ts
@@ -24,6 +24,7 @@ import {
 } from 'stream-chat';
 import { ChatClientService, ClientEvent } from './chat-client.service';
 import { createMessagePreview } from './message-preview';
+import { NotificationService } from './notification.service';
 import { getReadBy } from './read-by';
 import {
   AttachmentUpload,
@@ -101,6 +102,10 @@ export class ChannelService<
    * Emits the currently selected message to quote
    */
   messageToQuote$: Observable<StreamMessage<T> | undefined>;
+  /**
+   * Emits the ID of the message the message list should jump to (can be a channel message or thread message)
+   */
+  jumpToMessage$: Observable<{ id?: string; parentId?: string }>;
   /**
    * Emits the list of users that are currently typing in the channel (current user is not included)
    */
@@ -242,6 +247,10 @@ export class ChannelService<
   private activeThreadMessagesSubject = new BehaviorSubject<
     (StreamMessage<T> | MessageResponse<T> | FormatMessageResponse<T>)[]
   >([]);
+  private jumpToMessageSubject = new BehaviorSubject<{
+    id?: string;
+    parentId?: string;
+  }>({ id: undefined, parentId: undefined });
   private latestMessageDateByUserByChannelsSubject = new BehaviorSubject<{
     [key: string]: Date;
   }>({});
@@ -294,7 +303,8 @@ export class ChannelService<
 
   constructor(
     private chatClientService: ChatClientService<T>,
-    private ngZone: NgZone
+    private ngZone: NgZone,
+    private notificationService: NotificationService
   ) {
     this.channels$ = this.channelsSubject.asObservable();
     this.activeChannel$ = this.activeChannelSubject.asObservable();
@@ -336,6 +346,7 @@ export class ChannelService<
       shareReplay()
     );
     this.messageToQuote$ = this.messageToQuoteSubject.asObservable();
+    this.jumpToMessage$ = this.jumpToMessageSubject.asObservable();
 
     this.chatClientService.connectionState$
       .pipe(filter((s) => s === 'online'))
@@ -403,13 +414,18 @@ export class ChannelService<
     this.activeThreadMessagesSubject.next([]);
     this.latestMessageDateByUserByChannelsSubject.next({});
     this.selectMessageToQuote(undefined);
+    this.jumpToMessageSubject.next({ id: undefined, parentId: undefined });
   }
 
   /**
    * Sets the given `message` as an active parent message. If `undefined` is provided, it will deleselect the current parent message.
    * @param message
+   * @param loadMessagesForm
    */
-  async setAsActiveParentMessage(message: StreamMessage<T> | undefined) {
+  async setAsActiveParentMessage(
+    message: StreamMessage<T> | undefined,
+    loadMessagesForm: 'request' | 'state' = 'request'
+  ) {
     const messageToQuote = this.messageToQuoteSubject.getValue();
     if (messageToQuote && !!messageToQuote.parent_id) {
       this.messageToQuoteSubject.next(undefined);
@@ -417,24 +433,47 @@ export class ChannelService<
     if (!message) {
       this.activeParentMessageIdSubject.next(undefined);
       this.activeThreadMessagesSubject.next([]);
+      const messageToJumpTo = this.jumpToMessageSubject.getValue();
+      if (messageToJumpTo && !!messageToJumpTo.parentId) {
+        this.jumpToMessageSubject.next({ id: undefined, parentId: undefined });
+      }
     } else {
       this.activeParentMessageIdSubject.next(message.id);
       const activeChannel = this.activeChannelSubject.getValue();
-      const result = await activeChannel?.getReplies(message.id, {
-        limit: this.options?.message_limit,
-      });
-      this.activeThreadMessagesSubject.next(result?.messages || []);
+      if (loadMessagesForm === 'request') {
+        const result = await activeChannel?.getReplies(message.id, {
+          limit: this.options?.message_limit,
+        });
+        this.activeThreadMessagesSubject.next(result?.messages || []);
+      } else {
+        this.activeThreadMessagesSubject.next(
+          activeChannel?.state.threads[message.id] || []
+        );
+      }
     }
   }
 
   /**
    * Loads the next page of messages of the active channel. The page size can be set in the [query option](https://getstream.io/chat/docs/javascript/query_channels/?language=javascript#query-options) object.
+   * @param direction
    */
-  async loadMoreMessages() {
+  async loadMoreMessages(direction: 'older' | 'newer' = 'older') {
     const activeChnannel = this.activeChannelSubject.getValue();
-    const lastMessageId = this.activeChannelMessagesSubject.getValue()[0]?.id;
+    const messages = this.activeChannelMessagesSubject.getValue();
+    const lastMessageId =
+      messages[direction === 'older' ? 0 : messages.length - 1]?.id;
+    if (
+      direction === 'newer' &&
+      activeChnannel?.state?.latestMessages === activeChnannel?.state?.messages
+    ) {
+      // If we are on latest message set, activeChannelMessages$ will be refreshed by WS events, no need for a request
+      return;
+    }
     await activeChnannel?.query({
-      messages: { limit: this.options?.message_limit, id_lt: lastMessageId },
+      messages: {
+        limit: this.options?.message_limit,
+        [direction === 'older' ? 'id_lt' : 'id_gt']: lastMessageId,
+      },
       members: { limit: 0 },
       watchers: { limit: 0 },
     });
@@ -450,17 +489,24 @@ export class ChannelService<
 
   /**
    * Loads the next page of messages of the active thread. The page size can be set in the [query option](https://getstream.io/chat/docs/javascript/query_channels/?language=javascript#query-options) object.
+   * @param direction
    */
-  async loadMoreThreadReplies() {
+  async loadMoreThreadReplies(direction: 'older' | 'newer' = 'older') {
+    if (direction === 'newer') {
+      // Thread replies aren't broke into different message sets, activeThreadMessages$ will be refreshed by WS events, no need for a request
+      return;
+    }
     const activeChnannel = this.activeChannelSubject.getValue();
     const parentMessageId = this.activeParentMessageIdSubject.getValue();
     if (!parentMessageId) {
       return;
     }
-    const lastMessageId = this.activeThreadMessagesSubject.getValue()[0]?.id;
+    const threadMessages = this.activeThreadMessagesSubject.getValue();
+    const lastMessageId =
+      threadMessages[direction === 'older' ? 0 : threadMessages.length - 1]?.id;
     await activeChnannel?.getReplies(parentMessageId, {
       limit: this.options?.message_limit,
-      id_lt: lastMessageId,
+      [direction === 'older' ? 'id_lt' : 'id_gt']: lastMessageId,
     });
     this.activeThreadMessagesSubject.next(
       activeChnannel?.state.threads[parentMessageId] || []
@@ -792,6 +838,34 @@ export class ChannelService<
             ...channel.state.threads[preview.parent_id!],
           ])
         : this.activeChannelMessagesSubject.next([...channel.state.messages]);
+    }
+  }
+
+  /**
+   * Jumps to the selected message inside the message list, if the message is not yet loaded, it'll load the message (and it's surroundings) from the API.
+   * @param messageId The ID of the message to be loaded, 'latest' means jump to the latest messages
+   * @param parentMessageId The ID of the parent message if we want to load a thread message
+   */
+  async jumpToMessage(messageId: string, parentMessageId?: string) {
+    const activeChannel = this.activeChannelSubject.getValue();
+    try {
+      await activeChannel?.state.loadMessageIntoState(
+        messageId,
+        parentMessageId
+      );
+      const messages = activeChannel?.state.messages || [];
+      this.activeChannelMessagesSubject.next([...messages]);
+      if (parentMessageId) {
+        const parentMessage = messages.find((m) => m.id === parentMessageId);
+        void this.setAsActiveParentMessage(parentMessage, 'state');
+      }
+      this.jumpToMessageSubject.next({
+        id: messageId,
+        parentId: parentMessageId,
+      });
+    } catch (error) {
+      this.notificationService.addTemporaryNotification('Message not found');
+      throw error;
     }
   }
 

--- a/projects/stream-chat-angular/src/lib/message-list/message-list.component.html
+++ b/projects/stream-chat-angular/src/lib/message-list/message-list.component.html
@@ -29,6 +29,7 @@
           trackBy: trackByMessageId
         "
         class="str-chat__li str-chat__li--{{ groupStyles[i] }}"
+        id="{{ message.id }}"
       >
         <ng-container
           *ngTemplateOutlet="
@@ -76,8 +77,8 @@
       str-chat__message-notification-right
       str-chat__message-notification-scroll-to-latest
     "
-    (keyup.enter)="scrollToLatestMessage()"
-    (click)="scrollToLatestMessage()"
+    (keyup.enter)="jumpToLatestMessage()"
+    (click)="jumpToLatestMessage()"
   >
     <stream-icon
       style="display: inline-block; height: 24px"
@@ -102,12 +103,14 @@
     let-isLastSentMessage="isLastSentMessage"
     let-enabledMessageActions="enabledMessageActions"
     let-mode="mode"
+    let-isHighlighted="isHighlighted"
   >
     <stream-message
       [message]="messageInput"
       [isLastSentMessage]="isLastSentMessage"
       [enabledMessageActions]="enabledMessageActions"
       [mode]="mode"
+      [isHighlighted]="isHighlighted"
     ></stream-message>
   </ng-template>
   <ng-container

--- a/projects/stream-chat-angular/src/lib/message-list/message-list.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message-list/message-list.component.spec.ts
@@ -38,7 +38,7 @@ describe('MessageListComponent', () => {
   let queryTypingIndicator: () => HTMLElement | null;
   let queryTypingUserAvatars: () => AvatarComponent[];
 
-  beforeEach(fakeAsync(() => {
+  beforeEach(() => {
     channelServiceMock = mockChannelService();
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
@@ -92,16 +92,17 @@ describe('MessageListComponent', () => {
     const scrollContainer = queryScrollContainer()!;
     scrollContainer.style.maxHeight = '300px';
     scrollContainer.style.overflowY = 'auto';
-    tick(300);
     fixture.detectChanges();
-  }));
+  });
 
   it('should display messages', () => {
     const messages = channelServiceMock.activeChannelMessages$.getValue();
     messages[messages.length - 1].user!.id = 'not' + mockCurrentUser().id;
+    component.highlightedMessageId = messages[0].id;
     channelServiceMock.activeChannelMessages$.next([...messages]);
     fixture.detectChanges();
     const messagesComponents = queryMessageComponents();
+    const messageElements = queryMessages();
 
     expect(messagesComponents.length).toBe(messages.length);
     messagesComponents.forEach((m, i) => {
@@ -113,6 +114,12 @@ describe('MessageListComponent', () => {
       expect(m.enabledMessageActions).toEqual(component.enabledMessageActions);
 
       expect(m.mode).toBe(component.mode);
+
+      expect(m.isHighlighted).toBe(
+        messages[i].id === component.highlightedMessageId
+      );
+
+      expect(messageElements[i].id).toBe(messages[i].id);
     });
   });
 
@@ -146,20 +153,23 @@ describe('MessageListComponent', () => {
 
   it('should scroll to bottom, after loading the messages', () => {
     const scrollContainer = queryScrollContainer()!;
+    const scrollTop = Math.round(scrollContainer.scrollTop);
 
-    expect(scrollContainer.scrollTop).not.toBe(0);
-    expect(scrollContainer.scrollTop).toBe(
+    expect(scrollTop).not.toBe(0);
+    expect(scrollTop).toBe(
       scrollContainer.scrollHeight - scrollContainer.clientHeight
     );
   });
 
-  it(`shouldn't scroll to bottom, after loading the messages if direction is top to bottom`, () => {
+  it('should scroll to the latest message, after loading the messages if direction is top to bottom', () => {
+    spyOn(channelServiceMock, 'jumpToMessage');
     component.direction = 'top-to-bottom';
     component.ngOnChanges({ direction: {} as SimpleChange });
-    fixture.detectChanges();
-    const scrollContainer = queryScrollContainer()!;
 
-    expect(scrollContainer.scrollTop).toBe(0);
+    expect(channelServiceMock.jumpToMessage).toHaveBeenCalledWith(
+      'latest',
+      undefined
+    );
   });
 
   it(`shouldn't scroll to bottom, after an image has been loaded if direction is top to bottom`, () => {
@@ -218,9 +228,10 @@ describe('MessageListComponent', () => {
     );
 
     const scrollContainer = queryScrollContainer()!;
+    const scrollTop = Math.round(scrollContainer.scrollTop);
 
-    expect(scrollContainer.scrollTop).not.toBe(0);
-    expect(scrollContainer.scrollTop).toBe(
+    expect(scrollTop).not.toBe(0);
+    expect(scrollTop).toBe(
       scrollContainer.scrollHeight - scrollContainer.clientHeight
     );
   });
@@ -246,7 +257,7 @@ describe('MessageListComponent', () => {
     expect(scrollContainer.scrollTop).toBe(0);
   });
 
-  it('should load more messages, if user scrolls up', () => {
+  it('should load older messages, if user scrolls up', () => {
     spyOn(channelServiceMock, 'loadMoreMessages');
 
     const scrollContainer = queryScrollContainer()!;
@@ -254,10 +265,10 @@ describe('MessageListComponent', () => {
     scrollContainer.dispatchEvent(new Event('scroll'));
     fixture.detectChanges();
 
-    expect(channelServiceMock.loadMoreMessages).toHaveBeenCalledWith();
+    expect(channelServiceMock.loadMoreMessages).toHaveBeenCalledWith('older');
   });
 
-  it('should load more messages, if user scrolls down and direction is top-to-bottom', () => {
+  it('should load older messages, if user scrolls down and direction is top-to-bottom', () => {
     component.direction = 'top-to-bottom';
     component.ngOnChanges({ direction: {} as SimpleChange });
     fixture.detectChanges();
@@ -268,7 +279,32 @@ describe('MessageListComponent', () => {
     scrollContainer.dispatchEvent(new Event('scroll'));
     fixture.detectChanges();
 
-    expect(channelServiceMock.loadMoreMessages).toHaveBeenCalledWith();
+    expect(channelServiceMock.loadMoreMessages).toHaveBeenCalledWith('older');
+  });
+
+  it('should load newer messages, if user scrolls down', () => {
+    spyOn(channelServiceMock, 'loadMoreMessages');
+
+    const scrollContainer = queryScrollContainer()!;
+    scrollContainer.scrollTo({ top: scrollContainer.scrollHeight });
+    scrollContainer.dispatchEvent(new Event('scroll'));
+    fixture.detectChanges();
+
+    expect(channelServiceMock.loadMoreMessages).toHaveBeenCalledWith('newer');
+  });
+
+  it('should load newer messages, if user scrolls up and direction is top-to-bottom', () => {
+    component.direction = 'top-to-bottom';
+    component.ngOnChanges({ direction: {} as SimpleChange });
+    fixture.detectChanges();
+    spyOn(channelServiceMock, 'loadMoreMessages');
+
+    const scrollContainer = queryScrollContainer()!;
+    scrollContainer.scrollTo({ top: 0 });
+    scrollContainer.dispatchEvent(new Event('scroll'));
+    fixture.detectChanges();
+
+    expect(channelServiceMock.loadMoreMessages).toHaveBeenCalledWith('newer');
   });
 
   it('should handle channel change', () => {
@@ -292,6 +328,114 @@ describe('MessageListComponent', () => {
     fixture.detectChanges();
 
     expect(scrollContainer.scrollTop).not.toBe(0);
+  });
+
+  it('should scroll message into view and highlight it', () => {
+    const messageElements = queryMessages();
+    const message = messageElements[messageElements.length - 1];
+    spyOn(message, 'scrollIntoView');
+    channelServiceMock.jumpToMessage$.next({ id: message.id });
+
+    expect(message.scrollIntoView).toHaveBeenCalledWith(jasmine.anything());
+    expect(component.highlightedMessageId).toBe(message.id);
+  });
+
+  it('should scroll message into view and highlight it - parent message', () => {
+    const messageElements = queryMessages();
+    const message = messageElements[messageElements.length - 1];
+    spyOn(message, 'scrollIntoView');
+    channelServiceMock.jumpToMessage$.next({
+      id: 'thread-message',
+      parentId: message.id,
+    });
+
+    expect(message.scrollIntoView).toHaveBeenCalledWith(jasmine.anything());
+    expect(component.highlightedMessageId).toBe(message.id);
+  });
+
+  it('should remove the highlight after scroll', fakeAsync(() => {
+    expect(component.highlightedMessageId).toBeUndefined();
+
+    const messageElements = queryMessages();
+    const message = messageElements[messageElements.length - 1];
+    channelServiceMock.jumpToMessage$.next({ id: message.id });
+
+    expect(component.highlightedMessageId).toBe(message.id);
+
+    tick(500);
+    fixture.detectChanges();
+
+    expect(component.highlightedMessageId).toBeUndefined();
+  }));
+
+  it('should wait with scrolling until message has been rendered', () => {
+    const newMessages = generateMockMessages();
+    const message = newMessages[Math.round(newMessages.length / 2)];
+    message.id = 'new-message-id';
+    // Simulates the scenario when jumping requires a new message set to be loaded
+    channelServiceMock.activeChannelMessages$.next(newMessages);
+    channelServiceMock.jumpToMessage$.next({
+      id: message.id,
+      parentId: undefined,
+    });
+
+    expect(nativeElement.querySelector(`#${message.id}`)).toBeNull();
+
+    fixture.detectChanges();
+
+    expect(nativeElement.querySelector(`#${message.id}`)).not.toBeNull();
+  });
+
+  it('should set #isUserScrolled to true when not the latest message set is displayed', () => {
+    const newMessages = generateMockMessages(25, true);
+    // Replace the current messages with a compelitely new set
+    channelServiceMock.activeChannelMessages$.next(newMessages);
+    fixture.detectChanges();
+    component.scrollToBottom();
+    fixture.detectChanges();
+
+    expect(component.isUserScrolled).toBeTrue();
+  });
+
+  it('jump to "latest" message - direction "top-to-bottom"', () => {
+    const scrollContainer = queryScrollContainer()!;
+    scrollContainer.scrollTo({
+      top: (scrollContainer.scrollHeight - scrollContainer.clientHeight) / 2,
+    });
+    scrollContainer.dispatchEvent(new Event('scroll'));
+    fixture.detectChanges();
+
+    channelServiceMock.jumpToMessage$.next({ id: 'latest' });
+    fixture.detectChanges();
+
+    expect(Math.round(scrollContainer.scrollTop)).toBe(
+      scrollContainer.scrollHeight - scrollContainer.clientHeight
+    );
+  });
+
+  it('should turn of programatic scroll adjustment and message load while jumping to message', () => {
+    // This test uses private memebers to set up test cases, this is not nice, but this is because creating these cases otherwise would require a lot of complex logic
+    component.highlightedMessageId = 'messageId';
+    component['hasNewMessages'] = true;
+    spyOn(component, 'scrollToBottom');
+    component.ngAfterViewChecked();
+
+    expect(component['hasNewMessages']).toBeFalse();
+    expect(component.scrollToBottom).not.toHaveBeenCalled();
+
+    component['olderMassagesLoaded'] = true;
+    spyOn<any>(component, 'preserveScrollbarPosition');
+    component.ngAfterViewChecked();
+
+    expect(component['olderMassagesLoaded']).toBeFalse();
+
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
+
+    expect((component as any).preserveScrollbarPosition).not.toHaveBeenCalled();
+
+    expect((component as any).shouldLoadMoreMessages('bottom')).toBeFalse();
+
+    /* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
   });
 
   describe('if user scrolled up', () => {
@@ -351,12 +495,13 @@ describe('MessageListComponent', () => {
       ]);
       fixture.detectChanges();
 
-      expect(scrollContainer.scrollTop + scrollContainer.clientHeight).toBe(
-        scrollContainer.scrollHeight
-      );
+      expect(
+        Math.round(scrollContainer.scrollTop) + scrollContainer.clientHeight
+      ).toBe(scrollContainer.scrollHeight);
     });
 
-    it('should display scroll to bottom button and scroll to bottom if clicked', fakeAsync(() => {
+    it('should display scroll to latest message button and jump to latest messsage if clicked', fakeAsync(() => {
+      spyOn(channelServiceMock, 'jumpToMessage');
       const scrollContainer = queryScrollContainer()!;
       scrollContainer.scrollTo({
         top: (scrollContainer.scrollHeight - scrollContainer.clientHeight) / 2,
@@ -366,8 +511,9 @@ describe('MessageListComponent', () => {
       queryScrollToLatestButton()?.click();
       fixture.detectChanges();
 
-      expect(scrollContainer.scrollTop + scrollContainer.clientHeight).toBe(
-        scrollContainer.scrollHeight
+      expect(channelServiceMock.jumpToMessage).toHaveBeenCalledWith(
+        'latest',
+        undefined
       );
     }));
   });
@@ -383,6 +529,14 @@ describe('MessageListComponent', () => {
       });
       scrollContainer.dispatchEvent(new Event('scroll'));
       fixture.detectChanges();
+    });
+
+    it('jump to "latest" message', () => {
+      const scrollContainer = queryScrollContainer()!;
+      channelServiceMock.jumpToMessage$.next({ id: 'latest' });
+      fixture.detectChanges();
+
+      expect(Math.round(scrollContainer.scrollTop)).toBe(0);
     });
 
     it(`shouldn't scroll up for new messages`, () => {
@@ -436,11 +590,14 @@ describe('MessageListComponent', () => {
     });
 
     it('should display scroll to latest button and scroll to top if clicked', fakeAsync(() => {
-      const scrollContainer = queryScrollContainer()!;
+      spyOn(channelServiceMock, 'jumpToMessage');
       queryScrollToLatestButton()?.click();
       fixture.detectChanges();
 
-      expect(scrollContainer.scrollTop).toBe(0);
+      expect(channelServiceMock.jumpToMessage).toHaveBeenCalledWith(
+        'latest',
+        undefined
+      );
     }));
   });
 
@@ -493,7 +650,7 @@ describe('MessageListComponent', () => {
       expect(messagesComponents.length).toBe(messages.length);
     });
 
-    it('should load more replies, if user scrolls up', () => {
+    it('should load older replies, if user scrolls up', () => {
       spyOn(channelServiceMock, 'loadMoreThreadReplies');
 
       const scrollContainer = queryScrollContainer()!;
@@ -504,10 +661,12 @@ describe('MessageListComponent', () => {
       scrollContainer.dispatchEvent(new Event('scroll'));
       fixture.detectChanges();
 
-      expect(channelServiceMock.loadMoreThreadReplies).toHaveBeenCalledWith();
+      expect(channelServiceMock.loadMoreThreadReplies).toHaveBeenCalledWith(
+        'older'
+      );
     });
 
-    it(`should load more replies, if user scrolls up - shouldn't send unnecessary requests`, () => {
+    it(`should older replies, if user scrolls up - shouldn't send unnecessary requests`, () => {
       spyOn(channelServiceMock, 'loadMoreThreadReplies');
 
       const scrollContainer = queryScrollContainer()!;
@@ -521,9 +680,22 @@ describe('MessageListComponent', () => {
       scrollContainer.dispatchEvent(new Event('scroll'));
       fixture.detectChanges();
 
-      expect(
-        channelServiceMock.loadMoreThreadReplies
-      ).toHaveBeenCalledOnceWith();
+      expect(channelServiceMock.loadMoreThreadReplies).toHaveBeenCalledOnceWith(
+        'older'
+      );
+    });
+
+    it('should load newer replies, if user scrolls down', () => {
+      spyOn(channelServiceMock, 'loadMoreThreadReplies');
+
+      const scrollContainer = queryScrollContainer()!;
+      scrollContainer.scrollTo({ top: scrollContainer.scrollHeight });
+      scrollContainer.dispatchEvent(new Event('scroll'));
+      fixture.detectChanges();
+
+      expect(channelServiceMock.loadMoreThreadReplies).toHaveBeenCalledWith(
+        'newer'
+      );
     });
 
     it('should show parent message of thread', () => {
@@ -584,6 +756,37 @@ describe('MessageListComponent', () => {
       expect(avatars.length).toBe(2);
       expect(avatars[0].name).toBe('jack');
       expect(avatars[1].name).toBe('John');
+    });
+
+    it('should scroll thread message into view and highlight it', () => {
+      const messageElements = queryMessages();
+      const message = messageElements[messageElements.length - 1];
+      spyOn(message, 'scrollIntoView');
+      channelServiceMock.jumpToMessage$.next({
+        id: message.id,
+        parentId: undefined,
+      });
+
+      expect(message.scrollIntoView).not.toHaveBeenCalled();
+      expect(component.highlightedMessageId).toBe(undefined);
+
+      channelServiceMock.jumpToMessage$.next({
+        id: message.id,
+        parentId: 'parent-id',
+      });
+
+      expect(message.scrollIntoView).toHaveBeenCalledWith(jasmine.anything());
+      expect(component.highlightedMessageId).toBe(message.id);
+    });
+
+    it('should jump to latest message', () => {
+      spyOn(channelServiceMock, 'jumpToMessage');
+      component.jumpToLatestMessage();
+
+      expect(channelServiceMock.jumpToMessage).toHaveBeenCalledWith(
+        'latest',
+        component.parentMessage!.id
+      );
     });
   });
 });

--- a/projects/stream-chat-angular/src/lib/message/message.component.html
+++ b/projects/stream-chat-angular/src/lib/message/message.component.html
@@ -10,6 +10,7 @@
   [class.mobile-press]="isPressedOnMobile"
   [class.str-chat__message--has-attachment]="hasAttachment"
   [class.str-chat__message--with-reactions]="hasReactions"
+  [class.str-chat__message--highlighted]="isHighlighted"
   data-testid="message-container"
   (mouseleave)="isActionBoxOpen = false"
 >
@@ -373,6 +374,18 @@
     class="quoted-message"
     data-testid="quoted-message-container"
     [class.mine]="isSentByCurrentUser"
+    (click)="
+      jumpToMessage(
+        (message?.quoted_message)!.id,
+        message?.quoted_message?.parent_id
+      )
+    "
+    (keyup.enter)="
+      jumpToMessage(
+        (message?.quoted_message)!.id,
+        message?.quoted_message?.parent_id
+      )
+    "
   >
     <stream-avatar-placeholder
       data-testid="qouted-message-avatar"

--- a/projects/stream-chat-angular/src/lib/message/message.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message/message.component.spec.ts
@@ -53,12 +53,14 @@ describe('MessageComponent', () => {
   let queryReplyInThreadIcon: () => HTMLElement | null;
   let resendMessageSpy: jasmine.Spy;
   let setAsActiveParentMessageSpy: jasmine.Spy;
+  let jumpToMessageSpy: jasmine.Spy;
 
   beforeEach(() => {
     resendMessageSpy = jasmine.createSpy('resendMessage');
     setAsActiveParentMessageSpy = jasmine.createSpy(
       'setAsActiveParentMessageSpy'
     );
+    jumpToMessageSpy = jasmine.createSpy('jumpToMessage');
     currentUser = mockCurrentUser();
     TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
@@ -85,6 +87,7 @@ describe('MessageComponent', () => {
           useValue: {
             resendMessage: resendMessageSpy,
             setAsActiveParentMessage: setAsActiveParentMessageSpy,
+            jumpToMessage: jumpToMessageSpy,
           },
         },
       ],
@@ -990,12 +993,26 @@ describe('MessageComponent', () => {
     });
   });
 
+  it('should apply necessary CSS class, if highlighted', () => {
+    expect(
+      nativeElement.querySelector('.str-chat__message--highlighted')
+    ).toBeNull();
+
+    component.isHighlighted = true;
+    fixture.detectChanges();
+
+    expect(
+      nativeElement.querySelector('.str-chat__message--highlighted')
+    ).not.toBeNull();
+  });
+
   describe('quoted message', () => {
     const quotedMessageContainerSelector =
       '[data-testid="quoted-message-container"]';
+    let quotedMessage: StreamMessage<DefaultStreamChatGenerics>;
 
     beforeEach(() => {
-      const quotedMessage = mockMessage();
+      quotedMessage = mockMessage();
       quotedMessage.id = 'quoted-message';
       quotedMessage.user = { id: 'sara', name: 'Sara', image: 'url/to/img' };
       quotedMessage.attachments = [{ id: '1' }, { id: '2' }];
@@ -1064,6 +1081,17 @@ describe('MessageComponent', () => {
       fixture.detectChanges();
 
       expect(queryAttachmentComponent()).toBeDefined();
+    });
+
+    it('should jump to quoted message upon click', () => {
+      nativeElement
+        .querySelector<HTMLElement>(quotedMessageContainerSelector)!
+        .click();
+
+      expect(jumpToMessageSpy).toHaveBeenCalledWith(
+        quotedMessage.id,
+        quotedMessage.parent_id
+      );
     });
   });
 });

--- a/projects/stream-chat-angular/src/lib/message/message.component.ts
+++ b/projects/stream-chat-angular/src/lib/message/message.component.ts
@@ -59,6 +59,10 @@ export class MessageComponent implements OnInit, OnChanges, OnDestroy {
    * Determines if the message is being dispalyed in a channel or in a [thread](https://getstream.io/chat/docs/javascript/threads/?language=javascript).
    */
   @Input() mode: 'thread' | 'main' = 'main';
+  /**
+   * Highlighting is used to add visual emphasize to a message when jumping to the message
+   */
+  @Input() isHighlighted = false;
   canReceiveReadEvents: boolean | undefined;
   canReactToMessage: boolean | undefined;
   isEditing: boolean | undefined;
@@ -283,6 +287,10 @@ export class MessageComponent implements OnInit, OnChanges, OnDestroy {
         this.isActionBoxOpen = !this.isEditing;
       },
     };
+  }
+
+  jumpToMessage(messageId: string, parentMessageId?: string) {
+    void this.channelService.jumpToMessage(messageId, parentMessageId);
   }
 
   private createMessageParts() {

--- a/projects/stream-chat-angular/src/lib/types.ts
+++ b/projects/stream-chat-angular/src/lib/types.ts
@@ -147,6 +147,7 @@ export type MessageContext = {
   enabledMessageActions: string[];
   isLastSentMessage: boolean | undefined;
   mode: 'thread' | 'main';
+  isHighlighted: boolean;
 };
 
 export type ChannelActionsContext<


### PR DESCRIPTION
Jump to quoted message implemented:
- Scroll to message added inside message list
- Message list looks for unread messages even if the user is switched to an older messages list -> at the moment the message list does this by subscribing to `message.new` events, but a more Angulary solution would be: https://github.com/GetStream/stream-chat-angular/issues/369 - didn't want to invest the time now as pinned messages in itself is a big feature, but would be nice to do in the future
- Channel preview displays latest message using `channel.state.latestMessages` instead of `channel.state.messages`
- Bidirectional message load -> newer messages can be loaded if user scrolls down -> 

@petyosi just an FYI, I kept an eye for the page size problems for the message jump but didn't (yet) notice it, I'm not sure what caused the exact problem in React, but I have two guesses why it didn't come up:
- There is no scroll retry logic. If we want to jump to a message, the message list waits until the message is rendered and then scrolls
- Loading additional messages is turned off while jumping to a message is in progress (from the moment the scroll starts + 1000ms)