### PR TITLE
feat: Pin messages

### DIFF
--- a/projects/stream-chat-angular/src/assets/i18n/en.ts
+++ b/projects/stream-chat-angular/src/assets/i18n/en.ts
@@ -37,6 +37,7 @@ export const en = {
     'Message has been successfully flagged':
       'Message has been successfully flagged',
     'Message pinned': 'Message pinned',
+    'Message unpinned': 'Message unpinned',
     Mute: 'Mute',
     New: 'New',
     'New Messages!': 'New Messages!',

--- a/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.spec.ts
@@ -49,6 +49,8 @@ describe('MessageActionsBoxComponent', () => {
     deleteMessage: jasmine.Spy;
     selectMessageToQuote: jasmine.Spy;
     messageToQuote$: Observable<StreamMessage | undefined>;
+    pinMessage: jasmine.Spy;
+    unpinMessage: jasmine.Spy;
   };
 
   beforeEach(async () => {
@@ -59,6 +61,8 @@ describe('MessageActionsBoxComponent', () => {
       deleteMessage: jasmine.createSpy(),
       selectMessageToQuote: jasmine.createSpy(),
       messageToQuote$: new Observable(),
+      pinMessage: jasmine.createSpy(),
+      unpinMessage: jasmine.createSpy(),
     };
     await TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
@@ -161,7 +165,7 @@ describe('MessageActionsBoxComponent', () => {
 
     expect(queryDeleteAction()).not.toBeNull();
     expect(queryEditAction()).not.toBeNull();
-    expect(queryPinAction()).toBeNull();
+    expect(queryPinAction()).not.toBeNull();
     expect(queryMuteAction()).toBeNull();
     expect(queryFlagAction()).toBeNull();
     expect(queryQuoteAction()).toBeNull();
@@ -222,8 +226,7 @@ describe('MessageActionsBoxComponent', () => {
     expect(queryQuoteAction()).not.toBeNull();
   });
 
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('should display the pin action label correctly', () => {
+  it('should display the pin action label correctly', () => {
     component.message = { ...message, ...{ pinned: false } };
     component.enabledActions = ['pin-message'];
     component.ngOnChanges({
@@ -242,17 +245,21 @@ describe('MessageActionsBoxComponent', () => {
     expect(pinAction?.textContent).toContain('Unpin');
   });
 
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('should handle pin action', () => {
+  it('should handle pin action', () => {
     component.enabledActions = ['pin-message'];
     component.ngOnChanges({ enabledActions: {} as SimpleChange });
     fixture.detectChanges();
-    spyOn(window, 'alert').and.callThrough();
     const action = queryPinAction();
     action?.click();
     fixture.detectChanges();
 
-    expect(window.alert).toHaveBeenCalledWith(jasmine.anything());
+    expect(channelService.pinMessage).toHaveBeenCalledWith(component.message);
+
+    component.message!.pinned = true;
+    action?.click();
+    fixture.detectChanges();
+
+    expect(channelService.unpinMessage).toHaveBeenCalledWith(component.message);
   });
 
   it('should handle flag action', async () => {
@@ -307,7 +314,7 @@ describe('MessageActionsBoxComponent', () => {
     });
     fixture.detectChanges();
 
-    expect(spy).toHaveBeenCalledWith(2);
+    expect(spy).toHaveBeenCalledWith(3);
 
     spy.calls.reset();
     component.enabledActions = [
@@ -324,7 +331,7 @@ describe('MessageActionsBoxComponent', () => {
     });
     fixture.detectChanges();
 
-    expect(spy).toHaveBeenCalledWith(3);
+    expect(spy).toHaveBeenCalledWith(4);
   });
 
   describe('should display edit action', () => {

--- a/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts
+++ b/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts
@@ -101,8 +101,12 @@ export class MessageActionsBoxComponent implements OnChanges, OnDestroy {
         actionName: 'pin',
         actionLabelOrTranslationKey: () =>
           this.message?.pinned ? 'streamChat.Unpin' : 'streamChat.Pin',
-        actionHandler: () => alert('Feature not yet implemented'),
-        isVisible: () => false,
+        actionHandler: (message: StreamMessage) =>
+          message.pinned
+            ? this.channelService.unpinMessage(message)
+            : this.channelService.pinMessage(message),
+        isVisible: (enabledActions: string[]) =>
+          enabledActions.indexOf('pin-message') !== -1,
       },
       {
         actionName: 'flag',

--- a/projects/stream-chat-angular/src/lib/mocks/index.ts
+++ b/projects/stream-chat-angular/src/lib/mocks/index.ts
@@ -99,6 +99,7 @@ export const generateMockChannels = (length = 25) => {
       },
       state: {
         messages: generateMockMessages(),
+        pinnedMessages: [],
         threads: {},
         read: {},
         members: {


### PR DESCRIPTION
The final piece of the pin message functionality:
- pin and unpin actions implemented
- activeChannelPinnedMessages$ stream added to ChannelService
- No UI for pinned messages but integrators can inject their template inside the channel component (+ use `channelService.jumpToMessage` functionality to jump to the pinned message)

I'll create a guide for this, but with theme-v2 design and screenshots