### PR TITLE
fix: Jump to latest button appears if changed to an empty channel

### DIFF
--- a/projects/stream-chat-angular/src/lib/message-list/message-list.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message-list/message-list.component.spec.ts
@@ -690,6 +690,18 @@ describe('MessageListComponent', () => {
     expect(queryTypingUsers()?.textContent).toContain('jack, John');
   });
 
+  it(`shouldn't display scroll to latest button if there is no scrollbar`, () => {
+    const scrollContainer = queryScrollContainer();
+
+    scrollContainer!.style.maxHeight = `${scrollContainer!.scrollHeight}px`;
+    fixture.detectChanges();
+
+    component.scrolled();
+    fixture.detectChanges();
+
+    expect(queryScrollToLatestButton()).toBeNull();
+  });
+
   describe('thread mode', () => {
     beforeEach(() => {
       component.mode = 'thread';

--- a/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts
+++ b/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts
@@ -250,6 +250,12 @@ export class MessageListComponent
   }
 
   scrolled() {
+    if (
+      this.scrollContainer.nativeElement.scrollHeight ===
+      this.scrollContainer.nativeElement.clientHeight
+    ) {
+      return;
+    }
     const scrollPosition = this.getScrollPosition();
 
     this.isUserScrolled =


### PR DESCRIPTION
If we changed from a channel with a message list that has a scrollbar to a channel whose message list didn't, then the jump to the latest button appeared unnecessarily.

This problem was caused by the fact that a scroll event was when the message list didn't have a scrollbar (my guess is the scroll event happened in response to the height change in the message list, but not sure about that).