### PR TITLE
fix: Ionic hover problems in Safari

### DIFF
--- a/projects/stream-chat-angular/src/lib/message-list/message-list.component.html
+++ b/projects/stream-chat-angular/src/lib/message-list/message-list.component.html
@@ -24,6 +24,7 @@
         </div>
       </li>
       <li
+        tabindex="0"
         data-testclass="message"
         *ngFor="
           let message of messages$ | async;

--- a/projects/stream-chat-angular/src/lib/message/message.component.html
+++ b/projects/stream-chat-angular/src/lib/message/message.component.html
@@ -479,6 +479,7 @@
           str-chat__message-status
         "
         data-testid="delivered-indicator"
+        tabindex="0"
         [popper]="popperContent"
         [popperTrigger]="popperTriggerHover"
         [popperPlacement]="popperPlacementAuto"
@@ -505,6 +506,7 @@
           str-chat__message-status
         "
         data-testid="sending-indicator"
+        tabindex="0"
         [popper]="popperContent"
         [popperTrigger]="popperTriggerHover"
         [popperPlacement]="popperPlacementAuto"
@@ -530,6 +532,7 @@
           str-chat__message-status
         "
         data-testid="read-indicator"
+        tabindex="0"
         [popper]="popperContent"
         [popperTrigger]="popperTriggerHover"
         [popperPlacement]="popperPlacementAuto"


### PR DESCRIPTION
The problem: in Ionic apps on iOS Safari the hover actions didn't work - we don't seem to have this problem outside of Ionic, not sure about the reason for this