### PR TITLE
feat: Enhance reconnect #350

### DIFF
--- a/projects/stream-chat-angular/src/lib/channel.service.thread.spec.ts
+++ b/projects/stream-chat-angular/src/lib/channel.service.thread.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import { first } from 'rxjs/operators';
 import {
@@ -225,7 +225,7 @@ describe('ChannelService - threads', () => {
     expect(activeParentMessageSpy).toHaveBeenCalledWith(undefined);
   });
 
-  it('should deselect thread after reconnect', async () => {
+  it('should deselect thread after reconnect', fakeAsync(async () => {
     await init();
     let parentMessage!: StreamMessage;
     service.activeChannelMessages$.subscribe((m) => (parentMessage = m[0]));
@@ -233,10 +233,11 @@ describe('ChannelService - threads', () => {
     const spy = jasmine.createSpy();
     service.activeParentMessage$.subscribe(spy);
     spy.calls.reset();
-    connectionState$.next('online');
+    events$.next({ eventType: 'connection.recovered' } as ClientEvent);
+    tick();
 
     expect(spy).toHaveBeenCalledWith(undefined);
-  });
+  }));
 
   it('should not add readBy field to messages', async () => {
     await init();


### PR DESCRIPTION
Prioritizing this for a client: on mobile app if the app is paused the WS connection is closed, and when you resume a reconnect happens, so the shortcomings of the reconnect logic is more apparent there

closes #350 