### PR TITLE
fix: read by data is based on message.created_at #402

### DIFF
--- a/projects/stream-chat-angular/src/lib/read-by.spec.ts
+++ b/projects/stream-chat-angular/src/lib/read-by.spec.ts
@@ -7,7 +7,7 @@ describe('getReadBy', () => {
     const sender = { id: 'sender', name: 'Tess' };
 
     const message = {
-      updated_at: new Date('2021-09-14T13:08:30.004112Z'),
+      created_at: new Date('2021-09-14T13:08:30.004112Z'),
       user: sender,
     } as FormatMessageResponse<DefaultStreamChatGenerics>;
     const channel = {

--- a/projects/stream-chat-angular/src/lib/read-by.ts
+++ b/projects/stream-chat-angular/src/lib/read-by.ts
@@ -11,7 +11,7 @@ export const getReadBy = <
   Object.keys(channel.state.read).forEach((key) => {
     if (
       channel.state.read[key].last_read.getTime() >=
-        message.updated_at.getTime() &&
+        message.created_at.getTime() &&
       message.user?.id !== key
     ) {
       readBy.push(channel.state.read[key].user);


### PR DESCRIPTION
closes #402 