### PR TITLE
fix: Don't reset message input on channel update

### DIFF
--- a/projects/stream-chat-angular/src/lib/message-input/message-input.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message-input/message-input.component.spec.ts
@@ -338,6 +338,7 @@ describe('MessageInputComponent', () => {
       { file, state: 'success', url: 'http://url/to/image' },
     ]);
     const files = [file];
+    component.textareaValue = 'my message';
     await component.filesSelected(files as any as FileList);
     await component.messageSent();
 
@@ -427,6 +428,25 @@ describe('MessageInputComponent', () => {
 
     expect(component.textareaValue).toBe('');
     expect(attachmentService.resetAttachmentUploads).toHaveBeenCalledWith();
+  });
+
+  it('should not reset textarea and attachments if channel id remains the same', () => {
+    attachmentService.attachmentUploads$.next([
+      {
+        file: { name: 'img.png' } as any as File,
+        state: 'uploading',
+        type: 'image',
+      },
+    ]);
+    component.textareaValue = 'text';
+    mockActiveChannel$.next({
+      ...mockActiveChannel$.getValue(),
+      getConfig: () => ({ commands: [] }),
+    } as any as Channel<DefaultStreamChatGenerics>);
+    fixture.detectChanges();
+
+    expect(component.textareaValue).toBe('text');
+    expect(attachmentService.resetAttachmentUploads).not.toHaveBeenCalled();
   });
 
   it('should accept #message as input', () => {

--- a/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts
+++ b/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts
@@ -153,8 +153,10 @@ export class MessageInputComponent
     );
     this.subscriptions.push(
       this.channelService.activeChannel$.subscribe((channel) => {
-        this.textareaValue = '';
-        this.attachmentService.resetAttachmentUploads();
+        if (channel && this.channel && channel.id !== this.channel.id) {
+          this.textareaValue = '';
+          this.attachmentService.resetAttachmentUploads();
+        }
         const capabilities = channel?.data?.own_capabilities as string[];
         if (capabilities) {
           this.isFileUploadAuthorized =


### PR DESCRIPTION
closes #440 