### PR TITLE
Qualify link context

### DIFF
--- a/projects/stream-chat-angular/src/lib/message/message.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message/message.component.spec.ts
@@ -983,7 +983,7 @@ describe('MessageComponent', () => {
 
   it('should replace URL links inside text content', () => {
     component.message = {
-      html: '<p>This is a message with a link <a href="https://getstream.io/" rel="ugc nofollow">https://getstream.io/</a></p>\n',
+      html: '<p>This is a message with a link <a href="https://getstream.io/" rel="nofollow">https://getstream.io/</a></p>\n',
       text: 'This is a message with a link https://getstream.io/',
     } as any as StreamMessage;
     component.ngOnChanges({ message: {} as SimpleChange });

--- a/projects/stream-chat-angular/src/lib/message/message.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message/message.component.spec.ts
@@ -922,7 +922,7 @@ describe('MessageComponent', () => {
     expect(component.messageTextParts).toEqual([
       {
         content:
-          '<a href="https://getstream.io/" rel="nofollow">https://getstream.io/</a> this is the link ',
+          '<a href="https://getstream.io/" rel="ugc nofollow">https://getstream.io/</a> this is the link ',
         type: 'text',
       },
       { content: '@sara', type: 'mention', user: { id: 'sara' } },
@@ -983,20 +983,20 @@ describe('MessageComponent', () => {
 
   it('should replace URL links inside text content', () => {
     component.message = {
-      html: '<p>This is a message with a link <a href="https://getstream.io/" rel="nofollow">https://getstream.io/</a></p>\n',
+      html: '<p>This is a message with a link <a href="https://getstream.io/" rel="ugc nofollow">https://getstream.io/</a></p>\n',
       text: 'This is a message with a link https://getstream.io/',
     } as any as StreamMessage;
     component.ngOnChanges({ message: {} as SimpleChange });
 
     expect(component.messageTextParts![0].content).toContain(
-      ' <a href="https://getstream.io/" rel="nofollow">https://getstream.io/</a>'
+      ' <a href="https://getstream.io/" rel="ugc nofollow">https://getstream.io/</a>'
     );
 
     component.message.html = undefined;
     component.ngOnChanges({ message: {} as SimpleChange });
 
     expect(component.messageTextParts![0].content).toContain(
-      '<a href="https://getstream.io/" rel="nofollow">https://getstream.io/</a>'
+      '<a href="https://getstream.io/" rel="ugc nofollow">https://getstream.io/</a>'
     );
   });
 

--- a/projects/stream-chat-angular/src/lib/message/message.component.ts
+++ b/projects/stream-chat-angular/src/lib/message/message.component.ts
@@ -496,7 +496,7 @@ export class MessageComponent
     }
     content = content.replace(
       this.urlRegexp,
-      (match) => `<a href="${match}" rel="nofollow">${match}</a>`
+      (match) => `<a href="${match}" rel="ugc nofollow">${match}</a>`
     );
 
     return content;


### PR DESCRIPTION
## TL;DR
Google now recommends using `rel="ugc"` as a more specific edition of `rel="nofollow"`. This PR adjusts the link transformer to follow the recommendation.

## Why is this necessary?
While the `rel="nofollow"` attribute continues to work just fine since it's introduction to the world in 2005 by Google, Google now recommends being even more specific with `rel` attribute. Since 2020, they have recommended using the `rel="ugc"` attribute to _more specifically_ indicate that the link originates from a user. 

Read the official Google docs on this [qualifying outbound links](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links), or read more about the context of the decision on [conductor.com](https://www.conductor.com/academy/nofollow/#other-values-ugc-and-sponsored).

## What is changing?
Previously, the `MessageComponent:wrapLinskWithAnchorTag()` private method would generate anchor tags in the following form: `<a ... rel="nofollow">`.

Now, this is adapted to include **both** the "ugc" and the "nofollow" attribute values (`<a ... rel="ugc nofollow">`). While the Google Search docs above specifically say that using the "ugc" value alone is sufficient, I assume that StreamChat is targeting the widest possible accessibility limits, and using both values should only be more acceptable.

I also attempted to update the tests to match this change. However, without documentation on how to run the tests myself, I wasn't able to confirm that they still pass.