### PR TITLE
Open links in new tab

### DIFF
--- a/projects/stream-chat-angular/src/lib/message/message.component.spec.ts
+++ b/projects/stream-chat-angular/src/lib/message/message.component.spec.ts
@@ -922,7 +922,7 @@ describe('MessageComponent', () => {
     expect(component.messageTextParts).toEqual([
       {
         content:
-          '<a href="https://getstream.io/" rel="nofollow">https://getstream.io/</a> this is the link ',
+          '<a href="https://getstream.io/" target="_blank" rel="nofollow">https://getstream.io/</a> this is the link ',
         type: 'text',
       },
       { content: '@sara', type: 'mention', user: { id: 'sara' } },
@@ -989,14 +989,14 @@ describe('MessageComponent', () => {
     component.ngOnChanges({ message: {} as SimpleChange });
 
     expect(component.messageTextParts![0].content).toContain(
-      ' <a href="https://getstream.io/" rel="nofollow">https://getstream.io/</a>'
+      ' <a href="https://getstream.io/" target="_blank" rel="nofollow">https://getstream.io/</a>'
     );
 
     component.message.html = undefined;
     component.ngOnChanges({ message: {} as SimpleChange });
 
     expect(component.messageTextParts![0].content).toContain(
-      '<a href="https://getstream.io/" rel="nofollow">https://getstream.io/</a>'
+      '<a href="https://getstream.io/" target="_blank" rel="nofollow">https://getstream.io/</a>'
     );
   });
 

--- a/projects/stream-chat-angular/src/lib/message/message.component.ts
+++ b/projects/stream-chat-angular/src/lib/message/message.component.ts
@@ -496,7 +496,8 @@ export class MessageComponent
     }
     content = content.replace(
       this.urlRegexp,
-      (match) => `<a href="${match}" rel="nofollow">${match}</a>`
+      (match) =>
+        `<a href="${match}" target="_blank" rel="nofollow">${match}</a>`
     );
 
     return content;

--- a/projects/stream-chat-angular/src/lib/message/message.component.ts
+++ b/projects/stream-chat-angular/src/lib/message/message.component.ts
@@ -426,7 +426,7 @@ export class MessageComponent
       this.message!.mentioned_users.length === 0
     ) {
       content = this.fixEmojiDisplay(content);
-      content = this.wrapLinskWithAnchorTag(content);
+      content = this.wrapLinksWithAnchorTag(content);
       this.messageTextParts = [{ content, type: 'text' }];
     } else {
       this.messageTextParts = [];
@@ -435,7 +435,7 @@ export class MessageComponent
         const mention = `@${user.name || user.id}`;
         const precedingText = text.substring(0, text.indexOf(mention));
         let formattedPrecedingText = this.fixEmojiDisplay(precedingText);
-        formattedPrecedingText = this.wrapLinskWithAnchorTag(
+        formattedPrecedingText = this.wrapLinksWithAnchorTag(
           formattedPrecedingText
         );
         this.messageTextParts!.push({
@@ -451,7 +451,7 @@ export class MessageComponent
       });
       if (text) {
         text = this.fixEmojiDisplay(text);
-        text = this.wrapLinskWithAnchorTag(text);
+        text = this.wrapLinksWithAnchorTag(text);
         this.messageTextParts.push({ content: text, type: 'text' });
       }
     }
@@ -490,7 +490,7 @@ export class MessageComponent
     return content;
   }
 
-  private wrapLinskWithAnchorTag(content: string) {
+  private wrapLinksWithAnchorTag(content: string) {
     if (this.displayAs === 'html') {
       return content;
     }


### PR DESCRIPTION
This addresses the following issue which has already been approved:
* resolves #550 

## Why are we proposing this?
We're highly interested in seeing this issue through. Currently, clicking on links leaves our entire application which is quite jarring for our customers and makes it difficult to return to our application. Additionally, since we provide our webapp as a native app via [Capacitorjs](https://capacitorjs.com/), this could leave the user without any method of finding our app, short of quitting it and reopening it. Hitting the back navigation button may help, but it also may not always be available on our simple 

## What's Changing?
Making this adjustment became really straightforward because of the clarity of the current codebase. Similar to #558, this PR adjusts the behavior of the `Message:wrapLinksWithAnchorTag()` method to also include the `target="_blank"` attribute.

I also attempted to adjust the test cases to properly handle the new behavior. However, without the documentation to run the tests myself, I cannot confirm that I actually got them correct. Please give my any feedback or additional direction if changes are required, and I'll tackle them.