### PR TITLE
feat: make sure `channels$` stream never closes

### DIFF
--- a/docusaurus/angular_versioned_docs/version-5/basics/upgrade-v4.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/basics/upgrade-v4.mdx
@@ -108,6 +108,10 @@ The `ImageLoadService` is now removed. It's no longer required since the SDK use
 
 The `ChannelListToggleService` is now removed as it was only used in theme-v1. For theme-v2 please refer to the [responsive layout guide](../code-examples/responsive-layout.mdx).
 
+### Channel query error handling
+
+In previous versions if an error occured during channel load, the `channelService.channels$` Observable emitted an error, which would close the stream. Users would have to reload the page to be able to reinitialize the `ChannelService`. This isn't a sensible default behavior. From version 5 the `channels$` Observable will never emit an error, the channel query result can be observed using the [`channelService.channelQueryState$`](../../services/ChannelService/#channelquerystate). With this change the `options.keepAliveChannels$OnError` is no longer necessary, and has been removed.
+
 ### Type changes
 
 - Event handlers with `Function` type are changed to `() => void`

--- a/docusaurus/angular_versioned_docs/version-5/components/AttachmentListComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/AttachmentListComponent.mdx
@@ -122,7 +122,7 @@ The id of the message the attachments belong to
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts:39](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts#L39)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts:39](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts#L39)
 
 ---
 
@@ -134,7 +134,7 @@ The parent id of the message the attachments belong to
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts:43](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts#L43)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts:43](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts#L43)
 
 ---
 
@@ -146,7 +146,7 @@ The attachments to display
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts:47](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts#L47)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts:47](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts#L47)
 
 ---
 
@@ -158,6 +158,6 @@ Emits the state of the image carousel window
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts:51](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts#L51)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts:51](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-list/attachment-list.component.ts#L51)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/AttachmentPreviewListComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/AttachmentPreviewListComponent.mdx
@@ -47,7 +47,7 @@ A stream that emits the current file uploads and their states
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-preview-list/attachment-preview-list.component.ts:17](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-preview-list/attachment-preview-list.component.ts#L17)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-preview-list/attachment-preview-list.component.ts:17](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-preview-list/attachment-preview-list.component.ts#L17)
 
 ---
 
@@ -59,7 +59,7 @@ An output to notify the parent component if the user tries to retry a failed upl
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-preview-list/attachment-preview-list.component.ts:21](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-preview-list/attachment-preview-list.component.ts#L21)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-preview-list/attachment-preview-list.component.ts:21](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-preview-list/attachment-preview-list.component.ts#L21)
 
 ---
 
@@ -71,6 +71,6 @@ An output to notify the parent component if the user wants to delete a file
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-preview-list/attachment-preview-list.component.ts:25](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-preview-list/attachment-preview-list.component.ts#L25)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-preview-list/attachment-preview-list.component.ts:25](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-preview-list/attachment-preview-list.component.ts#L25)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/AutocompleteTextareaComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/AutocompleteTextareaComponent.mdx
@@ -51,7 +51,7 @@ TextareaInterface.value
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:49](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L49)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:49](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L49)
 
 ---
 
@@ -67,7 +67,7 @@ TextareaInterface.placeholder
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:53](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L53)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:53](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L53)
 
 ---
 
@@ -83,7 +83,7 @@ TextareaInterface.areMentionsEnabled
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:57](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L57)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:57](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L57)
 
 ---
 
@@ -99,7 +99,7 @@ TextareaInterface.inputMode
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:61](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L61)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:61](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L61)
 
 ---
 
@@ -115,7 +115,7 @@ TextareaInterface.mentionScope
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:65](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L65)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:65](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L65)
 
 ---
 
@@ -131,7 +131,7 @@ TextareaInterface.autoFocus
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:69](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L69)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:69](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L69)
 
 ---
 
@@ -147,7 +147,7 @@ TextareaInterface.valueChange
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:73](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L73)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:73](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L73)
 
 ---
 
@@ -163,7 +163,7 @@ TextareaInterface.send
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:77](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L77)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:77](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L77)
 
 ---
 
@@ -179,6 +179,6 @@ TextareaInterface.userMentions
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:81](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L81)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts:81](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/autocomplete-textarea/autocomplete-textarea.component.ts#L81)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/AvatarComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/AvatarComponent.mdx
@@ -71,7 +71,7 @@ An optional name of the image, used for fallback image or image title (if `image
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:35](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L35)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:35](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L35)
 
 ---
 
@@ -83,7 +83,7 @@ The URL of the image to be displayed. If the image can't be displayed the first 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:39](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L39)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:39](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L39)
 
 ---
 
@@ -95,7 +95,7 @@ The size in pixels of the avatar image.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:43](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L43)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:43](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L43)
 
 ---
 
@@ -107,7 +107,7 @@ The location the avatar will be displayed in
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:47](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L47)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:47](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L47)
 
 ---
 
@@ -119,7 +119,7 @@ The channel the avatar belongs to (if avatar of a channel is displayed)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:51](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L51)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:51](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L51)
 
 ---
 
@@ -131,7 +131,7 @@ The user the avatar belongs to (if avatar of a user is displayed)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:55](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L55)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:55](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L55)
 
 ---
 
@@ -143,7 +143,7 @@ The type of the avatar: channel if channel avatar is displayed, user if user ava
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:59](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L59)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:59](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L59)
 
 ---
 
@@ -155,7 +155,7 @@ If a channel avatar is displayed, and if the channel has exactly two members a g
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:63](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L63)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:63](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L63)
 
 ---
 
@@ -167,6 +167,6 @@ If channel/user image isn't provided the initials of the name of the channel/use
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:67](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L67)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts:67](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar/avatar.component.ts#L67)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/AvatarPlaceholderComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/AvatarPlaceholderComponent.mdx
@@ -12,7 +12,7 @@ An optional name of the image, used for fallback image or image title (if `image
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:23](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L23)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:23](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L23)
 
 ---
 
@@ -24,7 +24,7 @@ The URL of the image to be displayed. If the image can't be displayed the first 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:27](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L27)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:27](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L27)
 
 ---
 
@@ -36,7 +36,7 @@ The size in pixels of the avatar image.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:31](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L31)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:31](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L31)
 
 ---
 
@@ -48,7 +48,7 @@ The location the avatar will be displayed in
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:35](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L35)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:35](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L35)
 
 ---
 
@@ -60,7 +60,7 @@ The channel the avatar belongs to (if avatar of a channel is displayed)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:39](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L39)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:39](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L39)
 
 ---
 
@@ -72,7 +72,7 @@ The user the avatar belongs to (if avatar of a user is displayed)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:43](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L43)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:43](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L43)
 
 ---
 
@@ -84,7 +84,7 @@ The type of the avatar: channel if channel avatar is displayed, user if user ava
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:47](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L47)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:47](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L47)
 
 ---
 
@@ -96,7 +96,7 @@ If channel/user image isn't provided the initials of the name of the channel/use
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:51](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L51)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:51](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L51)
 
 ---
 
@@ -108,6 +108,6 @@ If a channel avatar is displayed, and if the channel has exactly two members a g
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:57](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L57)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts:57](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/avatar-placeholder/avatar-placeholder.component.ts#L57)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/ChannelPreviewComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/ChannelPreviewComponent.mdx
@@ -37,6 +37,6 @@ The channel to be displayed
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.ts:28](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.ts#L28)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.ts:28](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel-preview/channel-preview.component.ts#L28)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/IconComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/IconComponent.mdx
@@ -33,7 +33,7 @@ The icon to display, the list of [supported icons](https://github.com/GetStream/
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/icon/icon.component.ts:43](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/icon/icon.component.ts#L43)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/icon/icon.component.ts:43](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/icon/icon.component.ts#L43)
 
 ---
 
@@ -45,6 +45,6 @@ The size of the icon (in pixels)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/icon/icon.component.ts:47](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/icon/icon.component.ts#L47)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/icon/icon.component.ts:47](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/icon/icon.component.ts#L47)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/IconPlaceholderComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/IconPlaceholderComponent.mdx
@@ -12,7 +12,7 @@ The icon to display, the list of [supported icons](https://github.com/GetStream/
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/icon-placeholder/icon-placeholder.component.ts:18](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/icon-placeholder/icon-placeholder.component.ts#L18)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/icon-placeholder/icon-placeholder.component.ts:18](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/icon-placeholder/icon-placeholder.component.ts#L18)
 
 ---
 
@@ -24,6 +24,6 @@ The size of the icon (in pixels)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/icon-placeholder/icon-placeholder.component.ts:22](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/icon-placeholder/icon-placeholder.component.ts#L22)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/icon-placeholder/icon-placeholder.component.ts:22](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/icon-placeholder/icon-placeholder.component.ts#L22)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/LoadingIndicatorComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/LoadingIndicatorComponent.mdx
@@ -36,7 +36,7 @@ The size of the indicator (in pixels)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/loading-indicator/loading-indicator.component.ts:16](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/loading-indicator/loading-indicator.component.ts#L16)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/loading-indicator/loading-indicator.component.ts:16](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/loading-indicator/loading-indicator.component.ts#L16)
 
 ---
 
@@ -48,6 +48,6 @@ The color of the indicator
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/loading-indicator/loading-indicator.component.ts:21](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/loading-indicator/loading-indicator.component.ts#L21)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/loading-indicator/loading-indicator.component.ts:21](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/loading-indicator/loading-indicator.component.ts#L21)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/LoadingIndicatorPlaceholderComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/LoadingIndicatorPlaceholderComponent.mdx
@@ -12,7 +12,7 @@ The size of the indicator (in pixels)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.ts:17](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.ts#L17)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.ts:17](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.ts#L17)
 
 ---
 
@@ -24,6 +24,6 @@ The color of the indicator
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.ts:22](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.ts#L22)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.ts:22](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/loading-indicator-placeholder/loading-indicator-placeholder.component.ts#L22)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/MessageActionsBoxComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/MessageActionsBoxComponent.mdx
@@ -46,7 +46,7 @@ Indicates if the message actions are belonging to a message that was sent by the
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts:36](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts#L36)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts:36](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts#L36)
 
 ---
 
@@ -58,7 +58,7 @@ The message the actions will be executed on
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts:40](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts#L40)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts:40](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts#L40)
 
 ---
 
@@ -70,6 +70,6 @@ The list of [channel capabilities](https://getstream.io/chat/docs/javascript/cha
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts:44](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts#L44)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts:44](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-actions-box/message-actions-box.component.ts#L44)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/MessageComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/MessageComponent.mdx
@@ -73,7 +73,7 @@ The message to be displayed
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message/message.component.ts:58](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message/message.component.ts#L58)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message/message.component.ts:58](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message/message.component.ts#L58)
 
 ---
 
@@ -85,7 +85,7 @@ The list of [channel capabilities](https://getstream.io/chat/docs/javascript/cha
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message/message.component.ts:62](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message/message.component.ts#L62)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message/message.component.ts:62](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message/message.component.ts#L62)
 
 ---
 
@@ -97,7 +97,7 @@ If `true`, the message status (sending, sent, who read the message) is displayed
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message/message.component.ts:66](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message/message.component.ts#L66)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message/message.component.ts:66](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message/message.component.ts#L66)
 
 ---
 
@@ -109,7 +109,7 @@ Determines if the message is being dispalyed in a channel or in a [thread](https
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message/message.component.ts:70](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message/message.component.ts#L70)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message/message.component.ts:70](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message/message.component.ts#L70)
 
 ---
 
@@ -121,6 +121,6 @@ Highlighting is used to add visual emphasize to a message when jumping to the me
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message/message.component.ts:74](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message/message.component.ts#L74)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message/message.component.ts:74](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message/message.component.ts#L74)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/MessageInputComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/MessageInputComponent.mdx
@@ -60,7 +60,7 @@ If file upload is enabled, the user can open a file selector from the input. Ple
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:60](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L60)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:60](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L60)
 
 ---
 
@@ -72,7 +72,7 @@ If true, users can mention other users in messages. You also [need to use the `A
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:64](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L64)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:64](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L64)
 
 ---
 
@@ -84,7 +84,7 @@ The scope for user mentions, either members of the current channel of members of
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:68](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L68)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:68](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L68)
 
 ---
 
@@ -96,7 +96,7 @@ Determines if the message is being dispalyed in a channel or in a [thread](https
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:72](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L72)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:72](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L72)
 
 ---
 
@@ -108,7 +108,7 @@ If true, users can select multiple files to upload. If no value is provided, it 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:76](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L76)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:76](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L76)
 
 ---
 
@@ -120,7 +120,7 @@ The message to edit
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:80](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L80)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:80](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L80)
 
 ---
 
@@ -132,7 +132,7 @@ An observable that can be used to trigger message sending from the outside
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:84](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L84)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:84](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L84)
 
 ---
 
@@ -144,7 +144,7 @@ In `desktop` mode the `Enter` key will trigger message sending, in `mobile` mode
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:88](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L88)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:88](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L88)
 
 ---
 
@@ -156,7 +156,7 @@ Enables or disables auto focus on the textarea element
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:92](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L92)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:92](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L92)
 
 ---
 
@@ -168,6 +168,6 @@ Emits when a message was successfuly sent or updated
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:96](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L96)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts:96](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input.component.ts#L96)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/MessageListComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/MessageListComponent.mdx
@@ -33,7 +33,7 @@ Determines if the message list should display channel messages or [thread messag
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:53](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L53)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:53](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L53)
 
 ---
 
@@ -45,7 +45,7 @@ The direction of the messages in the list, `bottom-to-top` means newest message 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:57](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L57)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:57](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L57)
 
 ---
 
@@ -57,7 +57,7 @@ Determines what triggers the appearance of the message options: by default you c
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:61](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L61)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:61](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L61)
 
 ---
 
@@ -69,7 +69,7 @@ You can hide the "jump to latest" button while scrolling. A potential use-case f
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:67](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L67)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:67](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L67)
 
 ---
 
@@ -81,7 +81,7 @@ If `true` date separators will be displayed
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:71](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L71)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:71](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L71)
 
 ---
 
@@ -93,7 +93,7 @@ If `true` unread indicator will be displayed
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:75](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L75)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:75](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L75)
 
 ---
 
@@ -105,7 +105,7 @@ If date separators are displayed, you can set the horizontal position of the dat
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:79](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L79)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:79](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L79)
 
 ---
 
@@ -117,7 +117,7 @@ If date separators are displayed, you can set the horizontal position of the dat
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:83](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L83)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:83](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L83)
 
 ---
 
@@ -131,7 +131,7 @@ This is only applicable for `main` mode, as threads doesn't have read infromatio
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:90](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L90)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:90](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L90)
 
 ---
 
@@ -143,6 +143,6 @@ You can turn on and off the loading indicator that signals to users that more me
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:94](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L94)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts:94](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-list/message-list.component.ts#L94)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/MessageReactionsComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/MessageReactionsComponent.mdx
@@ -60,7 +60,7 @@ The id of the message the reactions belong to
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts:36](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L36)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts:36](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L36)
 
 ---
 
@@ -72,7 +72,7 @@ The number of reactions grouped by [reaction types](https://github.com/GetStream
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts:40](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L40)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts:40](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L40)
 
 ---
 
@@ -84,7 +84,7 @@ Indicates if the selector should be opened or closed. Adding a UI element to ope
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts:45](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L45)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts:45](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L45)
 
 ---
 
@@ -96,7 +96,7 @@ List of reactions of a [message](../types/stream-message.mdx), used to display t
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts:49](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L49)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts:49](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L49)
 
 ---
 
@@ -108,7 +108,7 @@ List of the user's own reactions of a [message](../types/stream-message.mdx), us
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts:53](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L53)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts:53](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L53)
 
 ---
 
@@ -120,6 +120,6 @@ Indicates if the selector should be opened or closed. Adding a UI element to ope
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts:57](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L57)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts:57](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-reactions/message-reactions.component.ts#L57)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/ModalComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/ModalComponent.mdx
@@ -28,7 +28,7 @@ If `true` the modal will be displayed, if `false` the modal will be hidden
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/modal/modal.component.ts:25](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/modal/modal.component.ts#L25)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/modal/modal.component.ts:25](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/modal/modal.component.ts#L25)
 
 ---
 
@@ -40,7 +40,7 @@ The content of the modal (can also be provided using `ng-content`)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/modal/modal.component.ts:29](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/modal/modal.component.ts#L29)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/modal/modal.component.ts:29](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/modal/modal.component.ts#L29)
 
 ---
 
@@ -52,6 +52,6 @@ Emits `true` if the modal becomes visible, and `false` if the modal is closed.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/modal/modal.component.ts:33](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/modal/modal.component.ts#L33)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/modal/modal.component.ts:33](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/modal/modal.component.ts#L33)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/NotificationComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/NotificationComponent.mdx
@@ -24,7 +24,7 @@ The type of the notification
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/notification/notification.component.ts:16](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/notification/notification.component.ts#L16)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/notification/notification.component.ts:16](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/notification/notification.component.ts#L16)
 
 ---
 
@@ -36,6 +36,6 @@ The content of the notification (can also be provided using `ng-content`)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/notification/notification.component.ts:20](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/notification/notification.component.ts#L20)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/notification/notification.component.ts:20](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/notification/notification.component.ts#L20)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/TextareaComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/TextareaComponent.mdx
@@ -48,7 +48,7 @@ TextareaInterface.value
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts:35](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts#L35)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts:35](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts#L35)
 
 ---
 
@@ -64,7 +64,7 @@ TextareaInterface.placeholder
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts:39](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts#L39)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts:39](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts#L39)
 
 ---
 
@@ -80,7 +80,7 @@ TextareaInterface.inputMode
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts:43](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts#L43)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts:43](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts#L43)
 
 ---
 
@@ -96,7 +96,7 @@ TextareaInterface.autoFocus
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts:47](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts#L47)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts:47](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts#L47)
 
 ---
 
@@ -112,7 +112,7 @@ TextareaInterface.valueChange
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts:51](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts#L51)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts:51](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts#L51)
 
 ---
 
@@ -128,6 +128,6 @@ TextareaInterface.send
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts:55](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts#L55)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts:55](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/textarea/textarea.component.ts#L55)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/VoiceRecordingComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/VoiceRecordingComponent.mdx
@@ -82,6 +82,6 @@ The voice recording attachment
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/voice-recording/voice-recording.component.ts:28](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/voice-recording/voice-recording.component.ts#L28)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/voice-recording/voice-recording.component.ts:28](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/voice-recording/voice-recording.component.ts#L28)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/components/VoiceRecordingWavebarComponent.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/components/VoiceRecordingWavebarComponent.mdx
@@ -34,7 +34,7 @@ The audio element that plays the voice recording
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/voice-recording/voice-recording-wavebar/voice-recording-wavebar.component.ts:28](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/voice-recording/voice-recording-wavebar/voice-recording-wavebar.component.ts#L28)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/voice-recording/voice-recording-wavebar/voice-recording-wavebar.component.ts:28](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/voice-recording/voice-recording-wavebar/voice-recording-wavebar.component.ts#L28)
 
 ---
 
@@ -46,7 +46,7 @@ The waveform data to visualize
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/voice-recording/voice-recording-wavebar/voice-recording-wavebar.component.ts:32](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/voice-recording/voice-recording-wavebar/voice-recording-wavebar.component.ts#L32)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/voice-recording/voice-recording-wavebar/voice-recording-wavebar.component.ts:32](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/voice-recording/voice-recording-wavebar/voice-recording-wavebar.component.ts#L32)
 
 ---
 
@@ -58,6 +58,6 @@ The duration of the voice recording in seconds
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/voice-recording/voice-recording-wavebar/voice-recording-wavebar.component.ts:36](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/voice-recording/voice-recording-wavebar/voice-recording-wavebar.component.ts#L36)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/voice-recording/voice-recording-wavebar/voice-recording-wavebar.component.ts:36](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/voice-recording/voice-recording-wavebar/voice-recording-wavebar.component.ts#L36)
 
 [//]: # "End of generated content"

--- a/docusaurus/angular_versioned_docs/version-5/services/AttachmentConfigurationService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/AttachmentConfigurationService.mdx
@@ -32,7 +32,7 @@ A custom handler can be provided to override the default giphy attachment (GIFs 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:37](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L37)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:37](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L37)
 
 ---
 
@@ -60,7 +60,7 @@ A custom handler can be provided to override the default image attachment (image
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:22](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L22)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:22](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L22)
 
 ---
 
@@ -86,7 +86,7 @@ A custom handler can be provided to override the default scraped image attachmen
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:43](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L43)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:43](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L43)
 
 ---
 
@@ -113,7 +113,7 @@ A custom handler can be provided to override the default video attachment (video
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:30](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L30)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:30](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L30)
 
 ---
 
@@ -125,7 +125,7 @@ You can turn on/off thumbnail generation for video attachments
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:49](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L49)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:49](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L49)
 
 ## Methods
 
@@ -147,7 +147,7 @@ Handles the configuration for giphy attachments, it's possible to provide your o
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:180](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L180)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:180](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L180)
 
 ---
 
@@ -171,7 +171,7 @@ Handles the configuration for image attachments, it's possible to provide your o
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:57](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L57)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:57](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L57)
 
 ---
 
@@ -193,7 +193,7 @@ Handles the configuration for scraped image attachments, it's possible to provid
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:200](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L200)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:200](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L200)
 
 ---
 
@@ -216,4 +216,4 @@ Handles the configuration for video attachments, it's possible to provide your o
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:123](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L123)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts:123](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment-configuration.service.ts#L123)

--- a/docusaurus/angular_versioned_docs/version-5/services/AttachmentService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/AttachmentService.mdx
@@ -18,7 +18,7 @@ Emits the number of uploads in progress.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment.service.ts:22](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment.service.ts#L22)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment.service.ts:22](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment.service.ts#L22)
 
 ---
 
@@ -30,7 +30,7 @@ Emits the state of the uploads ([`AttachmentUpload[]`](https://github.com/GetStr
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment.service.ts:26](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment.service.ts#L26)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment.service.ts:26](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment.service.ts#L26)
 
 ## Methods
 
@@ -54,7 +54,7 @@ Note: If you just want to use your own CDN for file uploads, you don't necessary
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment.service.ts:102](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment.service.ts#L102)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment.service.ts:102](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment.service.ts#L102)
 
 ---
 
@@ -76,7 +76,7 @@ Maps attachments received from the Stream API to uploads. This is useful when ed
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment.service.ts:188](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment.service.ts#L188)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment.service.ts:188](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment.service.ts#L188)
 
 ---
 
@@ -98,7 +98,7 @@ Deletes an attachment, the attachment can have any state (`error`, `uploading` o
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment.service.ts:127](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment.service.ts#L127)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment.service.ts:127](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment.service.ts#L127)
 
 ---
 
@@ -122,7 +122,7 @@ A promise with the result
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment.service.ts:54](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment.service.ts#L54)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment.service.ts:54](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment.service.ts#L54)
 
 ---
 
@@ -140,7 +140,7 @@ the attachments
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment.service.ts:157](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment.service.ts#L157)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment.service.ts:157](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment.service.ts#L157)
 
 ---
 
@@ -156,7 +156,7 @@ Resets the attachments uploads (for example after the message with the attachmen
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment.service.ts:45](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment.service.ts#L45)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment.service.ts:45](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment.service.ts#L45)
 
 ---
 
@@ -180,4 +180,4 @@ A promise with the result
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/attachment.service.ts:112](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/attachment.service.ts#L112)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/attachment.service.ts:112](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/attachment.service.ts#L112)

--- a/docusaurus/angular_versioned_docs/version-5/services/ChannelService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/ChannelService.mdx
@@ -24,7 +24,7 @@ The active channel will always be marked as read when a new message is received
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:98](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L98)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:97](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L97)
 
 ---
 
@@ -38,7 +38,7 @@ This property isn't always updated, please use `channel.read` to display up-to-d
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:150](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L150)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:149](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L149)
 
 ---
 
@@ -50,7 +50,7 @@ Emits the list of currently loaded messages of the active channel.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:102](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L102)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:101](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L101)
 
 ---
 
@@ -62,7 +62,7 @@ Emits the list of pinned messages of the active channel.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:106](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L106)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:105](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L105)
 
 ---
 
@@ -76,7 +76,7 @@ This property isn't always updated, please use `channel.read` to display up-to-d
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:156](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L156)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:155](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L155)
 
 ---
 
@@ -88,7 +88,7 @@ Emits the currently selected parent message. If no message is selected, it emits
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:118](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L118)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:117](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L117)
 
 ---
 
@@ -100,7 +100,7 @@ Emits the id of the currently selected parent message. If no message is selected
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:110](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L110)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:109](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L109)
 
 ---
 
@@ -112,7 +112,7 @@ Emits the list of currently loaded thread replies belonging to the selected pare
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:114](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L114)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:113](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L113)
 
 ---
 
@@ -138,7 +138,7 @@ The provided method will be called before a new message is sent to Stream's API.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:305](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L305)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:304](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L304)
 
 ---
 
@@ -164,7 +164,7 @@ The provided method will be called before a message is sent to Stream's API for 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:311](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L311)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:310](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L310)
 
 ---
 
@@ -178,7 +178,7 @@ If a message is bounced, it will be emitted via this `Observable`. The built-in 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:144](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L144)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:143](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L143)
 
 ---
 
@@ -190,7 +190,7 @@ The result of the latest channel query request.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:88](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L88)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:87](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L87)
 
 ---
 
@@ -222,11 +222,9 @@ It's important to note that filters don't apply to updates to the list from even
 
 Our platform documentation covers the topic of [channel events](https://getstream.io/chat/docs/javascript/event_object/?language=javascript#events) in depth.
 
-By default if an error occurs during channel load, the Observable will emit an error, which will close the stream. Users will have to reload the page to be able to reinitialize the `ChannelService`. If you don't want the streams to be closed, you can pass `options.keepAliveChannels$OnError = true` to the `init` method. In that case the `channelQueryState$` stream will emit the status of the latest channel load request.
-
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:84](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L84)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:83](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L83)
 
 ---
 
@@ -253,7 +251,7 @@ Custom event handler to call when the user is added to a channel, provide an eve
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:170](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L170)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:169](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L169)
 
 ---
 
@@ -284,7 +282,7 @@ Custom event handler to call when a channel is deleted, provide an event handler
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:190](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L190)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:189](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L189)
 
 ---
 
@@ -315,7 +313,7 @@ Custom event handler to call when a channel becomes hidden, provide an event han
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:232](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L232)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:231](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L231)
 
 ---
 
@@ -346,7 +344,7 @@ Custom event handler to call when a channel is truncated, provide an event handl
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:218](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L218)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:217](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L217)
 
 ---
 
@@ -377,7 +375,7 @@ Custom event handler to call when a channel is updated, provide an event handler
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:204](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L204)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:203](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L203)
 
 ---
 
@@ -408,7 +406,7 @@ Custom event handler to call when a channel becomes visible, provide an event ha
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:246](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L246)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:245](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L245)
 
 ---
 
@@ -435,7 +433,7 @@ You can override the default file delete request - override this if you use your
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:288](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L288)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:287](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L287)
 
 ---
 
@@ -462,7 +460,7 @@ You can override the default file upload request - you can use this to upload fi
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:274](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L274)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:273](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L273)
 
 ---
 
@@ -489,7 +487,7 @@ You can override the default image delete request - override this if you use you
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:292](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L292)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:291](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L291)
 
 ---
 
@@ -516,7 +514,7 @@ You can override the default image upload request - you can use this to upload i
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:281](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L281)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:280](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L280)
 
 ---
 
@@ -547,7 +545,7 @@ Custom event handler to call if a new message received from a channel that is be
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:260](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L260)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:259](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L259)
 
 ---
 
@@ -574,7 +572,7 @@ Custom event handler to call if a new message received from a channel that is no
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:160](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L160)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:159](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L159)
 
 ---
 
@@ -604,7 +602,7 @@ You can return either an offset, or a filter using the [`$lte`/`$gte` operator](
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:321](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L321)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:320](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L320)
 
 ---
 
@@ -631,7 +629,7 @@ Custom event handler to call when the user is removed from a channel, provide an
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:180](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L180)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:179](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L179)
 
 ---
 
@@ -643,7 +641,7 @@ Emits `false` if there are no more pages of channels that can be loaded.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:56](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L56)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:56](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L56)
 
 ---
 
@@ -655,7 +653,7 @@ Emits the ID of the message the message list should jump to (can be a channel me
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:126](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L126)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:125](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L125)
 
 ---
 
@@ -667,7 +665,7 @@ Emits a map that contains the date of the latest message sent by the current use
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:138](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L138)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:137](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L137)
 
 ---
 
@@ -693,7 +691,7 @@ The provided method will be called before deleting a message. If the returned Pr
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:299](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L299)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:298](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L298)
 
 ---
 
@@ -705,7 +703,7 @@ Emits the currently selected message to quote
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:122](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L122)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:121](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L121)
 
 ---
 
@@ -717,7 +715,7 @@ Emits the list of users that are currently typing in the channel (current user i
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:130](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L130)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:129](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L129)
 
 ---
 
@@ -729,7 +727,7 @@ Emits the list of users that are currently typing in the active thread (current 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:134](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L134)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:133](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L133)
 
 ---
 
@@ -741,7 +739,7 @@ internal
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:325](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L325)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:324](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L324)
 
 ## Accessors
 
@@ -757,7 +755,7 @@ The current active channel
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1523](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1523)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1520](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1520)
 
 ---
 
@@ -773,7 +771,7 @@ The current active channel messages
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1530](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1530)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1527](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1527)
 
 ---
 
@@ -789,7 +787,7 @@ The current list of channels
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1516](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1516)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1513](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1513)
 
 ---
 
@@ -805,7 +803,7 @@ If set to false, read events won't be sent as new messages are received. If set 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:498](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L498)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:495](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L495)
 
 • `set` **shouldMarkActiveChannelAsRead**(`shouldMarkActiveChannelAsRead`): `void`
 
@@ -823,7 +821,7 @@ If set to false, read events won't be sent as new messages are received. If set 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:505](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L505)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:502](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L502)
 
 ## Methods
 
@@ -846,7 +844,7 @@ The channel will be added to the beginning of the channel list
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1054](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1054)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1051](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1051)
 
 ---
 
@@ -870,7 +868,7 @@ Adds a reaction to a message.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:745](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L745)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:742](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L742)
 
 ---
 
@@ -894,7 +892,7 @@ The list of members matching the search filter
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:981](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L981)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:978](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L978)
 
 ---
 
@@ -916,7 +914,7 @@ Deletes an uploaded file by URL. If you want to know more about [file uploads](h
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:965](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L965)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:962](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L962)
 
 ---
 
@@ -939,7 +937,7 @@ Deletes the message from the active channel
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:867](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L867)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:864](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L864)
 
 ---
 
@@ -955,7 +953,7 @@ Deselects the currently active (if any) channel
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:552](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L552)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:549](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L549)
 
 ---
 
@@ -979,7 +977,7 @@ all reactions of a message
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1539](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1539)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1536](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1536)
 
 ---
 
@@ -991,12 +989,12 @@ Queries the channels with the given filters, sorts and options. More info about 
 
 #### Parameters
 
-| Name                     | Type                                                            | Default value | Description                                                                                                              |
-| :----------------------- | :-------------------------------------------------------------- | :------------ | :----------------------------------------------------------------------------------------------------------------------- |
-| `filters`                | `ChannelFilters`\<`T`\>                                         | `undefined`   |                                                                                                                          |
-| `sort?`                  | `ChannelSort`\<`T`\>                                            | `undefined`   |                                                                                                                          |
-| `options?`               | `ChannelOptions` & \{ `keepAliveChannels$OnError?`: `boolean` } | `undefined`   |                                                                                                                          |
-| `shouldSetActiveChannel` | `boolean`                                                       | `true`        | Decides if the first channel in the result should be made as an active channel, or no channel should be marked as active |
+| Name                     | Type                    | Default value | Description                                                                                                              |
+| :----------------------- | :---------------------- | :------------ | :----------------------------------------------------------------------------------------------------------------------- |
+| `filters`                | `ChannelFilters`\<`T`\> | `undefined`   |                                                                                                                          |
+| `sort?`                  | `ChannelSort`\<`T`\>    | `undefined`   |                                                                                                                          |
+| `options?`               | `ChannelOptions`        | `undefined`   |                                                                                                                          |
+| `shouldSetActiveChannel` | `boolean`               | `true`        | Decides if the first channel in the result should be made as an active channel, or no channel should be marked as active |
 
 #### Returns
 
@@ -1006,7 +1004,7 @@ the list of channels found by the query
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:682](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L682)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:679](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L679)
 
 ---
 
@@ -1029,7 +1027,7 @@ Jumps to the selected message inside the message list, if the message is not yet
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1150](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1150)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1147](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1147)
 
 ---
 
@@ -1045,7 +1043,7 @@ Loads the next page of channels. The page size can be set in the [query option](
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:735](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L735)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:732](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L732)
 
 ---
 
@@ -1067,7 +1065,7 @@ Loads the next page of messages of the active channel. The page size can be set 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:613](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L613)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:610](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L610)
 
 ---
 
@@ -1089,7 +1087,7 @@ Loads the next page of messages of the active thread. The page size can be set i
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:652](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L652)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:649](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L649)
 
 ---
 
@@ -1113,7 +1111,7 @@ the result of the request
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1572](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1572)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1569](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1569)
 
 ---
 
@@ -1135,7 +1133,7 @@ Pins the given message in the channel
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1179](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1179)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1176](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1176)
 
 ---
 
@@ -1158,7 +1156,7 @@ Removes a reaction from a message.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:761](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L761)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:758](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L758)
 
 ---
 
@@ -1180,7 +1178,7 @@ Resends the given message to the active channel
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:815](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L815)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:812](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L812)
 
 ---
 
@@ -1196,7 +1194,7 @@ Resets the `activeChannel$`, `channels$` and `activeChannelMessages$` Observable
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:718](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L718)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:715](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L715)
 
 ---
 
@@ -1218,7 +1216,7 @@ Selects or deselects the current message to quote reply to
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1045](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1045)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1042](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1042)
 
 ---
 
@@ -1242,7 +1240,7 @@ Selects or deselects the current message to quote reply to
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1008](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1008)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1005](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1005)
 
 ---
 
@@ -1269,7 +1267,7 @@ Sends a message to the active channel. The message is immediately added to the m
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:776](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L776)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:773](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L773)
 
 ---
 
@@ -1292,7 +1290,7 @@ If the channel wasn't previously part of the channel, it will be added to the be
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:520](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L520)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:517](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L517)
 
 ---
 
@@ -1315,7 +1313,7 @@ Sets the given `message` as an active parent message. If `undefined` is provided
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:578](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L578)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:575](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L575)
 
 ---
 
@@ -1337,7 +1335,7 @@ Call this method if user started typing in the active channel
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1499](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1499)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1496](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1496)
 
 ---
 
@@ -1359,7 +1357,7 @@ Call this method if user stopped typing in the active channel
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1508](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1508)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1505](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1505)
 
 ---
 
@@ -1381,7 +1379,7 @@ Removes the given message from pinned messages
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:1198](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L1198)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:1195](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L1195)
 
 ---
 
@@ -1403,7 +1401,7 @@ Updates the message in the active channel
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:832](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L832)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:829](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L829)
 
 ---
 
@@ -1427,4 +1425,4 @@ the result of file upload requests
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/channel.service.ts:899](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/channel.service.ts#L899)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/channel.service.ts:896](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/channel.service.ts#L896)

--- a/docusaurus/angular_versioned_docs/version-5/services/ChatClientService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/ChatClientService.mdx
@@ -18,7 +18,7 @@ Emits the current [application settings](https://getstream.io/chat/docs/javascri
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/chat-client.service.ts:49](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/chat-client.service.ts#L49)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/chat-client.service.ts:49](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/chat-client.service.ts#L49)
 
 ---
 
@@ -30,7 +30,7 @@ The [StreamChat client](https://github.com/GetStream/stream-chat-js/blob/master/
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/chat-client.service.ts:38](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/chat-client.service.ts#L38)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/chat-client.service.ts:38](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/chat-client.service.ts#L38)
 
 ---
 
@@ -42,7 +42,7 @@ Emits the current connection state of the user (`online` or `offline`)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/chat-client.service.ts:53](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/chat-client.service.ts#L53)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/chat-client.service.ts:53](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/chat-client.service.ts#L53)
 
 ---
 
@@ -57,7 +57,7 @@ For performance reasons this Observable operates outside of the Angular change d
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/chat-client.service.ts:45](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/chat-client.service.ts#L45)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/chat-client.service.ts:45](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/chat-client.service.ts#L45)
 
 ---
 
@@ -69,7 +69,7 @@ Emits the list of pending invites of the user. It emits every pending invitation
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/chat-client.service.ts:57](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/chat-client.service.ts#L57)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/chat-client.service.ts:57](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/chat-client.service.ts#L57)
 
 ---
 
@@ -81,7 +81,7 @@ Emits the current chat user
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/chat-client.service.ts:61](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/chat-client.service.ts#L61)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/chat-client.service.ts:61](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/chat-client.service.ts#L61)
 
 ## Methods
 
@@ -105,7 +105,7 @@ The users matching the search
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/chat-client.service.ts:209](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/chat-client.service.ts#L209)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/chat-client.service.ts:209](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/chat-client.service.ts#L209)
 
 ---
 
@@ -121,7 +121,7 @@ Disconnects the current user, and closes the WebSocket connection. Useful when d
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/chat-client.service.ts:178](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/chat-client.service.ts#L178)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/chat-client.service.ts:178](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/chat-client.service.ts#L178)
 
 ---
 
@@ -143,7 +143,7 @@ Flag the message with the given ID. If you want to know [more about flags](https
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/chat-client.service.ts:200](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/chat-client.service.ts#L200)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/chat-client.service.ts:200](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/chat-client.service.ts#L200)
 
 ---
 
@@ -159,7 +159,7 @@ Loads the current [application settings](https://getstream.io/chat/docs/javascri
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/chat-client.service.ts:188](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/chat-client.service.ts#L188)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/chat-client.service.ts:188](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/chat-client.service.ts#L188)
 
 ---
 
@@ -184,4 +184,4 @@ Creates a [`StreamChat`](https://github.com/GetStream/stream-chat-js/blob/668b3e
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/chat-client.service.ts:98](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/chat-client.service.ts#L98)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/chat-client.service.ts:98](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/chat-client.service.ts#L98)

--- a/docusaurus/angular_versioned_docs/version-5/services/CustomTemplatesService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/CustomTemplatesService.mdx
@@ -22,7 +22,7 @@ The template that can be used to override how attachment actions are displayed i
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:277](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L277)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:277](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L277)
 
 ---
 
@@ -34,7 +34,7 @@ The template used to display attachments of a [message](../components/MessageCom
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:117](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L117)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:117](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L117)
 
 ---
 
@@ -46,7 +46,7 @@ The template used to display attachments in the [message input](../components/Me
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:124](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L124)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:124](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L124)
 
 ---
 
@@ -58,7 +58,7 @@ The template used to display avatars for channels and users (instead of the [def
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:131](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L131)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:131](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L131)
 
 ---
 
@@ -70,7 +70,7 @@ The template that can be used to override how a card attachment is displayed ins
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:271](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L271)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:271](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L271)
 
 ---
 
@@ -82,7 +82,7 @@ The template for channel actions displayed in the [channel header](../components
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:110](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L110)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:110](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L110)
 
 ---
 
@@ -94,7 +94,7 @@ The template used to display additional information about a channel under the ch
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:228](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L228)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:228](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L228)
 
 ---
 
@@ -106,7 +106,7 @@ Template used to display the channel information inside the [channel list item](
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:336](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L336)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:336](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L336)
 
 ---
 
@@ -118,7 +118,7 @@ Template used to display an item in the [channel list](../components/ChannelList
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:68](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L68)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:68](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L68)
 
 ---
 
@@ -130,7 +130,7 @@ The autocomplete list item template for commands (used in the [`AutocompleteText
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:61](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L61)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:61](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L61)
 
 ---
 
@@ -142,7 +142,7 @@ The template used for displaying file upload/attachment selector inside the [mes
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:235](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L235)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:235](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L235)
 
 ---
 
@@ -154,7 +154,7 @@ Template to display custom metadata inside [message component](../components/Mes
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:221](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L221)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:221](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L221)
 
 ---
 
@@ -166,7 +166,7 @@ The template used to display the date separator inside the [message list](../com
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:289](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L289)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:289](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L289)
 
 ---
 
@@ -180,7 +180,7 @@ Displayed for the last message sent by the current user, if the message isn't ye
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:196](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L196)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:196](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L196)
 
 ---
 
@@ -192,7 +192,7 @@ The template used to display the [edit message form](../components/EditMessageFo
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:323](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L323)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:323](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L323)
 
 ---
 
@@ -204,7 +204,7 @@ The template for [emoji picker](../code-examples/emoji-picker.mdx)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:89](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L89)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:89](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L89)
 
 ---
 
@@ -216,7 +216,7 @@ The template to show if the main message list is empty
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:311](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L311)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:311](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L311)
 
 ---
 
@@ -228,7 +228,7 @@ The template to show if the thread message list is empty
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:317](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L317)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:317](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L317)
 
 ---
 
@@ -240,7 +240,7 @@ The template that can be used to override how a file attachment is displayed ins
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:265](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L265)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:265](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L265)
 
 ---
 
@@ -252,7 +252,7 @@ The template that can be used to override how image gallery is displayed inside 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:259](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L259)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:259](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L259)
 
 ---
 
@@ -264,7 +264,7 @@ Template for displaying icons (instead of the [default icon component](../compon
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:138](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L138)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:138](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L138)
 
 ---
 
@@ -276,7 +276,7 @@ The template that can be used to override how a single image attachment is displ
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:241](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L241)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:241](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L241)
 
 ---
 
@@ -288,7 +288,7 @@ Template for displaying the loading indicator (instead of the [default loading i
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:145](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L145)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:145](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L145)
 
 ---
 
@@ -300,7 +300,7 @@ The autocomplete list item template for mentioning users (used in the [`Autocomp
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:55](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L55)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:55](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L55)
 
 ---
 
@@ -312,7 +312,7 @@ The template used for displaying a [mention inside a message](../code-examples/m
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:82](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L82)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:82](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L82)
 
 ---
 
@@ -324,7 +324,7 @@ The template used for displaying an item in the [message actions box](../compone
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:159](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L159)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:159](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L159)
 
 ---
 
@@ -336,7 +336,7 @@ Template for displaying the message actions box (instead of the [default message
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:152](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L152)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:152](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L152)
 
 ---
 
@@ -348,7 +348,7 @@ The template used to display the [message bounce prompt](../components/MessageBo
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:329](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L329)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:329](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L329)
 
 ---
 
@@ -360,7 +360,7 @@ The message input template used when editing a message (instead of the [default 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:75](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L75)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:75](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L75)
 
 ---
 
@@ -372,7 +372,7 @@ The template used to display the reactions of a [message](../components/MessageC
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:166](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L166)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:166](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L166)
 
 ---
 
@@ -384,7 +384,7 @@ The template used to display a message in the [message list](../components/Messa
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:103](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L103)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:103](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L103)
 
 ---
 
@@ -396,7 +396,7 @@ The template used to display a modal window (instead of the [default modal](../c
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:173](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L173)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:173](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L173)
 
 ---
 
@@ -410,7 +410,7 @@ This UI element is used to separate unread messages from read messages
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:297](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L297)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:297](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L297)
 
 ---
 
@@ -424,7 +424,7 @@ Users can use this notification to jump to the first unread message when it's cl
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:305](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L305)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:305](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L305)
 
 ---
 
@@ -436,7 +436,7 @@ The template used to override the [default notification component](../components
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:180](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L180)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:180](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L180)
 
 ---
 
@@ -450,7 +450,7 @@ Displayed for the last message sent by the current user, if the message is read 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:214](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L214)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:214](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L214)
 
 ---
 
@@ -464,7 +464,7 @@ Displayed for the last message sent by the current user, if the message is curre
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:205](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L205)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:205](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L205)
 
 ---
 
@@ -476,7 +476,7 @@ The template used to display [system messages](https://getstream.io/chat/docs/ja
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:283](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L283)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:283](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L283)
 
 ---
 
@@ -488,7 +488,7 @@ The template used for header of a [thread](../components/ThreadComponent.mdx)
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:187](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L187)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:187](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L187)
 
 ---
 
@@ -500,7 +500,7 @@ The typing indicator template used in the [message list](../components/MessageLi
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:96](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L96)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:96](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L96)
 
 ---
 
@@ -512,7 +512,7 @@ The template that can be used to override how a video attachment is displayed in
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:253](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L253)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:253](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L253)
 
 ---
 
@@ -524,4 +524,4 @@ The template that can be used to override how a voice recording attachment is di
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/custom-templates.service.ts:247](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L247)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/custom-templates.service.ts:247](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/custom-templates.service.ts#L247)

--- a/docusaurus/angular_versioned_docs/version-5/services/DateParserService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/DateParserService.mdx
@@ -26,7 +26,7 @@ Custom parser to override `parseDate`
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/date-parser.service.ts:18](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/date-parser.service.ts#L18)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/date-parser.service.ts:18](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/date-parser.service.ts#L18)
 
 ---
 
@@ -52,7 +52,7 @@ Custom parser to override `parseDateTime`
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/date-parser.service.ts:22](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/date-parser.service.ts#L22)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/date-parser.service.ts:22](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/date-parser.service.ts#L22)
 
 ---
 
@@ -78,7 +78,7 @@ Custom parser to override `parseTime`
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/date-parser.service.ts:14](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/date-parser.service.ts#L14)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/date-parser.service.ts:14](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/date-parser.service.ts#L14)
 
 ## Methods
 
@@ -102,7 +102,7 @@ The parsed date
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/date-parser.service.ts:43](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/date-parser.service.ts#L43)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/date-parser.service.ts:43](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/date-parser.service.ts#L43)
 
 ---
 
@@ -126,7 +126,7 @@ The parsed date
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/date-parser.service.ts:55](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/date-parser.service.ts#L55)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/date-parser.service.ts:55](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/date-parser.service.ts#L55)
 
 ---
 
@@ -150,4 +150,4 @@ The parsed time
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/date-parser.service.ts:31](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/date-parser.service.ts#L31)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/date-parser.service.ts:31](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/date-parser.service.ts#L31)

--- a/docusaurus/angular_versioned_docs/version-5/services/EmojiInputService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/EmojiInputService.mdx
@@ -12,4 +12,4 @@ If you have an emoji picker in your application, you can propagate the selected 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/emoji-input.service.ts:14](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/emoji-input.service.ts#L14)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/emoji-input.service.ts:14](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/emoji-input.service.ts#L14)

--- a/docusaurus/angular_versioned_docs/version-5/services/MessageActionsService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/MessageActionsService.mdx
@@ -32,7 +32,7 @@ By default the [`MessageComponent`](../../components/MessageComponent) will disp
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-actions.service.ts:122](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-actions.service.ts#L122)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-actions.service.ts:122](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-actions.service.ts#L122)
 
 ---
 
@@ -44,7 +44,7 @@ You can pass your own custom actions that will be displayed inside the built-in 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-actions.service.ts:118](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-actions.service.ts#L118)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-actions.service.ts:118](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-actions.service.ts#L118)
 
 ---
 
@@ -56,7 +56,7 @@ Default actions - these are the actions that are handled by the built-in compone
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-actions.service.ts:26](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-actions.service.ts#L26)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-actions.service.ts:26](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-actions.service.ts#L26)
 
 ---
 
@@ -68,7 +68,7 @@ The built-in components will handle changes to this observable.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-actions.service.ts:114](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-actions.service.ts#L114)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-actions.service.ts:114](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-actions.service.ts#L114)
 
 ## Methods
 
@@ -93,4 +93,4 @@ the count
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-actions.service.ts:136](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-actions.service.ts#L136)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-actions.service.ts:136](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-actions.service.ts#L136)

--- a/docusaurus/angular_versioned_docs/version-5/services/MessageInputConfigService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/MessageInputConfigService.mdx
@@ -12,7 +12,7 @@ If true, users can mention other users in messages. You also [need to use the `A
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts:17](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts#L17)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts:17](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts#L17)
 
 ---
 
@@ -24,7 +24,7 @@ In `desktop` mode the `Enter` key will trigger message sending, in `mobile` mode
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts:30](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts#L30)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts:30](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts#L30)
 
 ---
 
@@ -36,7 +36,7 @@ If file upload is enabled, the user can open a file selector from the input. Ple
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts:13](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts#L13)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts:13](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts#L13)
 
 ---
 
@@ -48,7 +48,7 @@ If `false`, users can only upload one attachment per message
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts:21](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts#L21)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts:21](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts#L21)
 
 ---
 
@@ -60,4 +60,4 @@ The scope for user mentions, either members of the current channel of members of
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts:25](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts#L25)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts:25](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-input/message-input-config.service.ts#L25)

--- a/docusaurus/angular_versioned_docs/version-5/services/MessageReactionsService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/MessageReactionsService.mdx
@@ -28,7 +28,7 @@ The event handler can retrieve all reactions of a message inside the active chan
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-reactions.service.ts:31](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-reactions.service.ts#L31)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-reactions.service.ts:31](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-reactions.service.ts#L31)
 
 ---
 
@@ -42,7 +42,7 @@ You can provide any string as a reaction. The emoji can be provided as a string,
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-reactions.service.ts:18](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-reactions.service.ts#L18)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-reactions.service.ts:18](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-reactions.service.ts#L18)
 
 ## Accessors
 
@@ -58,7 +58,7 @@ Get the currently enabled reactions
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-reactions.service.ts:45](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-reactions.service.ts#L45)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-reactions.service.ts:45](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-reactions.service.ts#L45)
 
 • `set` **reactions**(`reactions`): `void`
 
@@ -76,4 +76,4 @@ Sets the enabled reactions
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message-reactions.service.ts:38](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message-reactions.service.ts#L38)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message-reactions.service.ts:38](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message-reactions.service.ts#L38)

--- a/docusaurus/angular_versioned_docs/version-5/services/MessageService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/MessageService.mdx
@@ -26,7 +26,7 @@ You can provide a custom method to display links
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message.service.ts:24](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message.service.ts#L24)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message.service.ts:24](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message.service.ts#L24)
 
 ---
 
@@ -43,4 +43,4 @@ If you display messages as text the following parts are still be displayed as HT
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/message.service.ts:17](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/message.service.ts#L17)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/message.service.ts:17](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/message.service.ts#L17)

--- a/docusaurus/angular_versioned_docs/version-5/services/NotificationService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/NotificationService.mdx
@@ -12,7 +12,7 @@ Emits the currently active [notifications](https://github.com/GetStream/stream-c
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/notification.service.ts:15](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/notification.service.ts#L15)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/notification.service.ts:15](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/notification.service.ts#L15)
 
 ## Methods
 
@@ -51,7 +51,7 @@ A method to clear the notification.
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/notification.service.ts:68](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/notification.service.ts#L68)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/notification.service.ts:68](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/notification.service.ts#L68)
 
 ---
 
@@ -91,4 +91,4 @@ A method to clear the notification (before the timeout).
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/notification.service.ts:31](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/notification.service.ts#L31)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/notification.service.ts:31](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/notification.service.ts#L31)

--- a/docusaurus/angular_versioned_docs/version-5/services/StreamI18nService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/StreamI18nService.mdx
@@ -23,4 +23,4 @@ Registers the translation to the [ngx-translate](https://github.com/ngx-translat
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/stream-i18n.service.ts:19](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/stream-i18n.service.ts#L19)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/stream-i18n.service.ts:19](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/stream-i18n.service.ts#L19)

--- a/docusaurus/angular_versioned_docs/version-5/services/ThemeService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/ThemeService.mdx
@@ -12,4 +12,4 @@ A Subject that can be used to get or set the currently active theme. By default 
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/theme.service.ts:14](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/theme.service.ts#L14)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/theme.service.ts:14](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/theme.service.ts#L14)

--- a/docusaurus/angular_versioned_docs/version-5/services/TransliterationService.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/services/TransliterationService.mdx
@@ -22,4 +22,4 @@ the result of the transliteration
 
 #### Defined in
 
-[projects/stream-chat-angular/src/lib/transliteration.service.ts:16](https://github.com/GetStream/stream-chat-angular/blob/7b41a2694fc8f1b2c1ec325a4b1ac7faf9d826dd/projects/stream-chat-angular/src/lib/transliteration.service.ts#L16)
+[stream-chat-angular/projects/stream-chat-angular/src/lib/transliteration.service.ts:16](https://github.com/GetStream/stream-chat-angular/blob/1780eb2818bdbdaa0627275d4b409e2b7e56d2b0/projects/stream-chat-angular/src/lib/transliteration.service.ts#L16)

--- a/projects/stream-chat-angular/src/lib/channel.service.spec.ts
+++ b/projects/stream-chat-angular/src/lib/channel.service.spec.ts
@@ -48,7 +48,7 @@ describe('ChannelService', () => {
   let init: (
     c?: Channel<DefaultStreamChatGenerics>[],
     sort?: ChannelSort<DefaultStreamChatGenerics>,
-    options?: ChannelOptions & { keepAliveChannels$OnError?: boolean },
+    options?: ChannelOptions,
     mockChannelQuery?: Function,
     shouldSetActiveChannel?: boolean
   ) => Promise<Channel<DefaultStreamChatGenerics>[]>;
@@ -88,7 +88,7 @@ describe('ChannelService', () => {
     init = async (
       channels?: Channel<DefaultStreamChatGenerics>[],
       sort?: ChannelSort<DefaultStreamChatGenerics>,
-      options?: ChannelOptions & { keepAliveChannels$OnError?: boolean },
+      options?: ChannelOptions,
       mockChannelQuery?: Function,
       shouldSetActiveChannel?: boolean
     ) => {
@@ -190,7 +190,7 @@ describe('ChannelService', () => {
     service.activeChannel$.subscribe(activeChannelSpy);
 
     try {
-      void init(undefined, undefined, { keepAliveChannels$OnError: true }, () =>
+      void init(undefined, undefined, undefined, () =>
         mockChatClient.queryChannels.and.rejectWith('there was an error')
       );
       tick();


### PR DESCRIPTION
BREAKING CHANGE: `options.keepAliveChannels$OnError` is no longer necessary, and has been removed