### PR TITLE
feat: align the default reaction set with other SDKs #310

### DIFF
--- a/docusaurus/angular_versioned_docs/version-5/basics/upgrade-v4.mdx
+++ b/docusaurus/angular_versioned_docs/version-5/basics/upgrade-v4.mdx
@@ -117,6 +117,10 @@ In previous versions if an error occured during channel load, the `channelServic
 - Event handlers with `Function` type are changed to `() => void`
 - Event handlers with `any` return types are changed to `void` return type
 
+### Default reactions
+
+To better align with other SDKs, the default reaction has been changed: the `angry` reaction is removed. You can provide your own reaction set using the [`MessageReactionsService`](../../services/MessageReactionsService/#reactions)
+
 ## Other changes
 
 ### Unused packages

--- a/projects/stream-chat-angular/src/lib/message-reactions.service.ts
+++ b/projects/stream-chat-angular/src/lib/message-reactions.service.ts
@@ -16,12 +16,11 @@ export class MessageReactionsService {
    * You can provide any string as a reaction. The emoji can be provided as a string, if you want to use custom images for reactions you have to provide a [custom reactions UI](../../services/CustomTemplatesService/#messagereactionstemplate)
    */
   reactions$ = new BehaviorSubject<{ [key in MessageReactionType]: string }>({
-    like: '👍',
-    angry: '😠',
-    love: '❤️',
     haha: '😂',
-    wow: '😮',
+    like: '👍',
+    love: '❤️',
     sad: '😞',
+    wow: '😮',
   });
   /**
    * By default the [`MessageReactionsComponent`](../../components/MessageReactionsComponent) will display the reacting users when a reaction is clicked. You can override this with your own UI by providing a custom event handler.


### PR DESCRIPTION
BREAKING CHANGE: the `angry` reaction is removed

closes #310 