### PR TITLE
fix: custom styles bundle fails to import icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@ngx-translate/core": "^13.0.0",
         "@ngx-translate/http-loader": "^6.0.0",
         "@popperjs/core": "^2.11.5",
-        "@stream-io/stream-chat-css": "4.15.0",
+        "@stream-io/stream-chat-css": "4.16.1",
         "@stream-io/transliterate": "^1.5.2",
         "angular-mentions": "^1.4.0",
         "dayjs": "^1.10.7",
@@ -4441,9 +4441,9 @@
       "dev": true
     },
     "node_modules/@stream-io/stream-chat-css": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@stream-io/stream-chat-css/-/stream-chat-css-4.15.0.tgz",
-      "integrity": "sha512-FW8f/lBvActFIFngjsxLGwjmMm1CaZdjpQ0oBQhrdiT70sOJ7qCzEdFTkKN0qAIThPT6XU9V5VRna+JfIS9sZg=="
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@stream-io/stream-chat-css/-/stream-chat-css-4.16.1.tgz",
+      "integrity": "sha512-wVYWBQKL2Bn0UsflqVQMdRoU6ajIaICPs272GiMWgibfWctVIkltDbDHcaeHuvJEOFkLM9tv8ibN5l49G2RLfw=="
     },
     "node_modules/@stream-io/transliterate": {
       "version": "1.5.2",
@@ -27745,9 +27745,9 @@
       "dev": true
     },
     "@stream-io/stream-chat-css": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@stream-io/stream-chat-css/-/stream-chat-css-4.15.0.tgz",
-      "integrity": "sha512-FW8f/lBvActFIFngjsxLGwjmMm1CaZdjpQ0oBQhrdiT70sOJ7qCzEdFTkKN0qAIThPT6XU9V5VRna+JfIS9sZg=="
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@stream-io/stream-chat-css/-/stream-chat-css-4.16.1.tgz",
+      "integrity": "sha512-wVYWBQKL2Bn0UsflqVQMdRoU6ajIaICPs272GiMWgibfWctVIkltDbDHcaeHuvJEOFkLM9tv8ibN5l49G2RLfw=="
     },
     "@stream-io/transliterate": {
       "version": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@ngx-translate/core": "^13.0.0",
     "@ngx-translate/http-loader": "^6.0.0",
     "@popperjs/core": "^2.11.5",
-    "@stream-io/stream-chat-css": "4.15.0",
+    "@stream-io/stream-chat-css": "4.16.1",
     "@stream-io/transliterate": "^1.5.2",
     "angular-mentions": "^1.4.0",
     "dayjs": "^1.10.7",


### PR DESCRIPTION
For custom style bundles it's now possible to provide asset path like this `@use "stream-chat-angular/src/assets/styles/v2/scss/_variables.scss" with ($assetsPath: "../../assets");`