### PR TITLE
fix: message menu reopened after adding reaction

### DIFF
--- a/projects/stream-chat-angular/src/lib/message/message.component.ts
+++ b/projects/stream-chat-angular/src/lib/message/message.component.ts
@@ -292,11 +292,7 @@ export class MessageComponent
     }
     this.subscriptions.push(
       this.messageActionsService.messageMenuOpenedFor$.subscribe((id) => {
-        if (this.message && this.message.id === id) {
-          if (!this.areMessageOptionsOpen) {
-            this.messageMenuTrigger?.show();
-          }
-        } else if (
+        if (
           (id === undefined || this.message?.id !== id) &&
           this.areMessageOptionsOpen
         ) {


### PR DESCRIPTION
https://linear.app/stream/issue/ANG-44/message-actions-reopened-after-adding-reaction